### PR TITLE
feat: track link clicks via server-side redirect

### DIFF
--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -19,7 +19,7 @@ export function ProfileCard({
             </CardHeader>
 
             <CardContent className="space-y-3">
-                <ProfileLinks links={user.links} />
+                <ProfileLinks links={user.links} username={username} />
                 {showCTA && <ProfileCTA />}
             </CardContent>
         </Card>

--- a/app/[username]/ProfileLinkItem.tsx
+++ b/app/[username]/ProfileLinkItem.tsx
@@ -1,13 +1,13 @@
 import { ArrowRight,Globe } from "lucide-react";
 import { PLATFORM_ICONS } from "../../lib/platformIcons";
 
-export function ProfileLinkItem({ link }: { link: any }) {
+export function ProfileLinkItem({ link,username }: { link: any,username:string }) {
     const Icon =
         PLATFORM_ICONS[link.platform] ?? Globe;
 
     return (
         <a
-            href={link.url}
+            href={`/${username}/${link.platform}`}
             target="_blank"
             rel="noopener noreferrer"
             className="group flex items-center justify-between rounded-lg border bg-background px-4 py-3 transition hover:bg-muted"

--- a/app/[username]/ProfileLinks.tsx
+++ b/app/[username]/ProfileLinks.tsx
@@ -1,7 +1,7 @@
 import { ProfileLinkItem } from "./ProfileLinkItem";
 import { EmptyProfileState } from "./EmptyProfileState";
 
-export function ProfileLinks({ links }: { links: any[] }) {
+export function ProfileLinks({ links,username }: { links: any[] ,username:string}) {
     if (links.length === 0) {
         return <EmptyProfileState />;
     }
@@ -9,7 +9,7 @@ export function ProfileLinks({ links }: { links: any[] }) {
     return (
         <div className="space-y-3">
             {links.map((link) => (
-                <ProfileLinkItem key={link.id} link={link} />
+                <ProfileLinkItem key={link.id} link={link} username = {username} />
             ))}
         </div>
     );


### PR DESCRIPTION
feat: fix click tracking to profile links

- Route profile links through /{username}/{platform} instead of direct URLs
- Increment click count on each visit via PlatformRedirect
- Add clicks field to Link model
- Pass username prop through ProfileLinks and ProfileLinkItem

closes #24 