### PR TITLE
fix(validation): prevent adding non-public or session-based URLs 

### DIFF
--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -13,13 +13,13 @@ export async function PUT(
     context: { params: Promise<{ id: string }> }
 ) {
     const session = await getServerSession(authOptions);
+
     if (!session?.user?.email) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const { id } = await context.params;
     const { url } = await req.json();
-    
 
     if (!url || typeof url !== "string") {
         return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
@@ -35,19 +35,10 @@ export async function PUT(
     }
 
     const finalUrl = normalizeUrl(url);
-        if (
-            finalUrl.includes("/messaging/") ||
-            finalUrl.includes("/feed/")
-        ) {
-            return NextResponse.json(
-                { error: "Please enter a valid public link" },
-                { status: 400 }
-            );
-        }
 
     if (!validatePlatformUrl(link.platform as any, finalUrl)) {
         return NextResponse.json(
-            { error: `Invalid ${link.platform} URL` },
+            { error: "Please enter a valid public link" },
             { status: 400 }
         );
     }
@@ -65,6 +56,7 @@ export async function DELETE(
     context: { params: Promise<{ id: string }> }
 ) {
     const session = await getServerSession(authOptions);
+
     if (!session?.user?.email) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -19,6 +19,7 @@ export async function PUT(
 
     const { id } = await context.params;
     const { url } = await req.json();
+    
 
     if (!url || typeof url !== "string") {
         return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
@@ -34,6 +35,15 @@ export async function PUT(
     }
 
     const finalUrl = normalizeUrl(url);
+        if (
+            finalUrl.includes("/messaging/") ||
+            finalUrl.includes("/feed/")
+        ) {
+            return NextResponse.json(
+                { error: "Please enter a valid public link" },
+                { status: 400 }
+            );
+        }
 
     if (!validatePlatformUrl(link.platform as any, finalUrl)) {
         return NextResponse.json(

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -15,10 +15,7 @@ export async function POST(req: Request) {
     const session = await getServerSession(authOptions);
 
     if (!session?.user?.email) {
-        return NextResponse.json(
-            { error: "Unauthorized" },
-            { status: 401 }
-        );
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const body = await req.json();

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -33,8 +33,17 @@ export async function POST(req: Request) {
             { status: 400 }
         );
     }
-
     const finalUrl = normalizeUrl(rawUrl);
+    if (
+        finalUrl.includes("/messaging/") ||
+        finalUrl.includes("/feed")
+    ) {
+        return NextResponse.json(
+            {error: "Please enter a valid public link"},
+            {status: 400}
+        );
+    }
+    
     const detectedPlatform = detectPlatform(finalUrl);
 
     if (!detectedPlatform) {
@@ -66,6 +75,17 @@ export async function POST(req: Request) {
         finalLabel =
             detectedPlatform.charAt(0).toUpperCase() +
             detectedPlatform.slice(1);
+    }
+
+    //block non-public link  
+    if (
+        finalUrl.includes("/messaging/") ||
+        finalUrl.includes("/feed/")
+    ) {
+        return NextResponse.json(
+           { error: "Please enter a valid public link" },
+           { status: 400 }
+        );
     }
 
     if (!validatePlatformUrl(detectedPlatform, finalUrl)) {

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -2,18 +2,23 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+
 import {
     detectPlatform,
     normalizeUrl,
     validatePlatformUrl,
 } from "@/lib/platforms";
+
 import { isValidHttpUrl } from "@/lib/url";
 
 export async function POST(req: Request) {
     const session = await getServerSession(authOptions);
 
     if (!session?.user?.email) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        return NextResponse.json(
+            { error: "Unauthorized" },
+            { status: 401 }
+        );
     }
 
     const body = await req.json();
@@ -33,17 +38,8 @@ export async function POST(req: Request) {
             { status: 400 }
         );
     }
+
     const finalUrl = normalizeUrl(rawUrl);
-    if (
-        finalUrl.includes("/messaging/") ||
-        finalUrl.includes("/feed")
-    ) {
-        return NextResponse.json(
-            {error: "Please enter a valid public link"},
-            {status: 400}
-        );
-    }
-    
     const detectedPlatform = detectPlatform(finalUrl);
 
     if (!detectedPlatform) {
@@ -77,20 +73,9 @@ export async function POST(req: Request) {
             detectedPlatform.slice(1);
     }
 
-    //block non-public link  
-    if (
-        finalUrl.includes("/messaging/") ||
-        finalUrl.includes("/feed/")
-    ) {
-        return NextResponse.json(
-           { error: "Please enter a valid public link" },
-           { status: 400 }
-        );
-    }
-
     if (!validatePlatformUrl(detectedPlatform, finalUrl)) {
         return NextResponse.json(
-            { error: `Invalid ${finalLabel} URL` },
+            { error: "Please enter a valid public link" },
             { status: 400 }
         );
     }
@@ -100,7 +85,10 @@ export async function POST(req: Request) {
     });
 
     if (!user) {
-        return NextResponse.json({ error: "User not found" }, { status: 404 });
+        return NextResponse.json(
+            { error: "User not found" },
+            { status: 404 }
+        );
     }
 
     const maxOrder = await prisma.link.aggregate({
@@ -129,10 +117,10 @@ export async function POST(req: Request) {
         }
 
         console.error(err);
+
         return NextResponse.json(
             { error: "Something went wrong" },
             { status: 500 }
         );
     }
-
 }

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -39,6 +39,7 @@ export function detectPlatform(url: string): Platform {
             return platform as Platform;
         }
     }
+
     return "website";
 }
 
@@ -47,11 +48,13 @@ export function validatePlatformUrl(
     url: string
 ): boolean {
     const normalized = normalizeUrl(url);
-    if(
+
+    if (
         normalized.includes("/messaging/") ||
         normalized.includes("/feed/")
     ) {
         return false;
     }
+
     return PLATFORM_PATTERNS[platform].test(normalized);
 }

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -12,7 +12,7 @@ export type Platform =
 
 const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     github: /^https?:\/\/(www\.)?github\.com\/[^/]+/i,
-    linkedin: /^https?:\/\/(www\.)?linkedin\.com\/in\/[^/]+/i,
+    linkedin: /^https?:\/\/(www\.)?linkedin\.com\/(in|company)\/[^/]+/i,
     leetcode: /^https?:\/\/(www\.)?leetcode\.com\/[^/]+/i,
     youtube: /^https?:\/\/(www\.)?youtube\.com\/[^/]+/i,
     x: /^https?:\/\/(www\.)?x\.com\/[^/]+/i,
@@ -39,7 +39,6 @@ export function detectPlatform(url: string): Platform {
             return platform as Platform;
         }
     }
-
     return "website";
 }
 
@@ -48,5 +47,11 @@ export function validatePlatformUrl(
     url: string
 ): boolean {
     const normalized = normalizeUrl(url);
+    if(
+        normalized.includes("/messaging/") ||
+        normalized.includes("/feed/")
+    ) {
+        return false;
+    }
     return PLATFORM_PATTERNS[platform].test(normalized);
 }


### PR DESCRIPTION
### NSOC'26
##  What i have done

I have added validation to prevent users from adding non-public or session-based URLs.

---

##  Problem

Previously, the app allowed any type of URL to be added, including links like:

- linkedin.com/messaging/...
- linkedin.com/feed/...

These links are not publicly accessible and only work for the user who created them.  
This leads to broken or useless links when shared.

---

##  Solution Implemented

- Added validation to block URLs containing:
  - `/messaging/`
  - `/feed/`
- Allowed only valid public links (e.g., LinkedIn profile `/in/`, `/company/`)
- Displayed a clear error message:
  - "Please enter a valid public link"
- Centralized validation logic inside `lib/platforms.ts`
- Removed duplicate validation checks from API routes

---

##  Changes Made

- Updated `lib/platforms.ts` to handle URL validation logic
- Updated `app/api/links/route.ts` (POST) to use centralized validation
- Updated `app/api/links/[id]/route.ts` (PUT) to use the same validation
- Ensured no duplicate checks exist in API

---

##  Testing

-  messaging links are rejected  
-  feed links are rejected  
-  valid public profile links are accepted  
-  error message is shown for invalid inputs  

<img width="879" height="1000" alt="Screenshot from 2026-04-17 18-47-39" src="https://github.com/user-attachments/assets/5be123d9-0d2d-4c40-a8cf-e0e30dc3d76c" />


---

## Result

This improves the reliability of shared links and ensures that users can only add meaningful and publicly accessible URLs.

---

##  Review

This PR was implemented as part of NSOC-26.  
Kindly review my PR and let me know if any improvements are needed.


Thank you!


closes issue #21 