### PR TITLE
# [Good First Issue] Add More Platforms #1

### DIFF
--- a/lib/platformIcons.ts
+++ b/lib/platformIcons.ts
@@ -9,7 +9,8 @@ import {
     Instagram,
     Twitch,
 } from "lucide-react";
-import { FaDiscord } from "react-icons/fa";
+import { FaDiscord, FaDribbble, FaMedium } from "react-icons/fa";
+import { SiHashnode, SiDevdotto } from "react-icons/si";
 
 export const PLATFORM_ICONS: Record<string, any> = {
     github: Github,
@@ -23,4 +24,8 @@ export const PLATFORM_ICONS: Record<string, any> = {
     instagram: Instagram,
     twitch: Twitch,
     discord: FaDiscord,
+    hashnode: SiHashnode,
+    devto: SiDevdotto,
+    medium: FaMedium,
+    dribbble: FaDribbble,
 };

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -8,6 +8,10 @@ export type Platform =
     | "instagram"
     | "discord"
     | "twitch"
+    | "hashnode"
+    | "devto"
+    | "medium"
+    | "dribbble"
     | "website";
 
 const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
@@ -20,6 +24,10 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     instagram: /^https?:\/\/(www\.)?instagram\.com\/[^/]+/i,
     discord: /^https?:\/\/(www\.)?discord\.com\/users\/[^/]+/i,
     twitch: /^https?:\/\/(www\.)?twitch\.tv\/[^/]+/i,
+    hashnode: /^https?:\/\/([^/]+\.)?hashnode\.(com|dev)(\/[^/]+)?/i,
+    devto: /^https?:\/\/(www\.)?dev\.to\/[^/]+/i,
+    medium: /^https?:\/\/(www\.)?medium\.com\/@?[^/]+/i,
+    dribbble: /^https?:\/\/(www\.)?dribbble\.com\/[^/]+/i,
     website: /^https?:\/\/.+/i,
 };
 


### PR DESCRIPTION
## Summary
- Added `hashnode`, `devto`, `medium`, `dribbble` to the `Platform` type
- Added URL regex patterns for each in `PLATFORM_PATTERNS`
- Added icons via `react-icons` (`SiHashnode`, `SiDevdotto`, `FaMedium`, `FaDribbble`)

## How it works
Platforms are auto-detected when a user pastes a URL — no UI changes needed.

## Test plan
- [ ] Paste `https://hashnode.com/@username` → detects as Hashnode with correct icon
- [ ] Paste `https://dev.to/username` → detects as Dev.to
- [ ] Paste `https://medium.com/@username` → detects as Medium
- [ ] Paste `https://dribbble.com/username` → detects as Dribbble
- [ ] No TypeScript errors (`tsc --noEmit`)
