### PR TITLE
feat: add active state indicator in landing page navbar

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,8 +1,32 @@
+"use client";
 import Link from "next/link";
+import { useState, useEffect  } from "react";   
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/app/components/ThemeToggle";
 
 export function Navbar() {
+    const [activeSection, setActiveSection] = useState("");
+    useEffect(() => {
+    const sectionIds = ["features", "how", "demo"];
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    setActiveSection(entry.target.id);
+                }
+            });
+        },
+        { threshold: 0.6 }
+    );
+
+    sectionIds.forEach((id) => {
+        const el = document.getElementById(id);
+        if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+}, []);
     return (
         <header className="sticky top-0 z-50 border-b bg-background/70 backdrop-blur">
             <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
@@ -13,13 +37,13 @@ export function Navbar() {
 
                 {/* Center nav */}
                 <nav className="hidden md:flex items-center gap-8 text-sm text-muted-foreground">
-                    <a href="#features" className="hover:text-foreground">
+                    <a href="#features" className={activeSection === "features" ? "text-foreground font-medium border-b-2 border-primary pb-0.5" : "text-muted-foreground hover:text-foreground hover:border-b-2 hover:border-primary hover:pb-0.5"}>
                         Features
                     </a>
-                    <a href="#how" className="hover:text-foreground">
+                    <a href="#how" className={activeSection === "how" ? "text-foreground font-medium border-b-2 border-primary pb-0.5" : "text-muted-foreground hover:text-foreground hover:border-b-2 hover:border-primary hover:pb-0.5"}>
                         How it works
                     </a>
-                    <a href="#demo" className="hover:text-foreground">
+                    <a href="#demo" className={activeSection === "demo" ? "text-foreground font-medium border-b-2 border-primary pb-0.5" : "text-muted-foreground hover:text-foreground hover:border-b-2 hover:border-primary hover:pb-0.5"}>
                         Demo
                     </a>
                 </nav>


### PR DESCRIPTION
##Closes: issue #54 

## Description:
The landing page navbar had no visual indication of the user's 
current section. This PR adds an active state to navbar links 
that updates dynamically as the user scrolls.

## Changes:
- Added `"use client"` directive to Navbar.tsx
- Added `useState` to track the currently active section
- Added `IntersectionObserver` via `useEffect` to detect which 
  section is in the viewport (triggers at 60% visibility)
- Updated nav link classNames to apply active styles 
  (bold text + primary color underline) when section is active
- Added hover underline effect on inactive links

##Screenshot: 
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/504790d1-f483-48f4-bce5-b957e72c9049" />
