### PR TITLE
fix: use PATCH method in EditProfileCard to match API route

### DIFF
--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -42,7 +42,7 @@ export default function EditProfileCard({
         const csrfToken = await getCsrfToken();
 
         const res = await fetch("/api/profile/update", {
-            method: "POST",
+            method: "PATCH",
             headers: {
                 "Content-Type": "application/json",
                 "x-csrf-token": csrfToken,


### PR DESCRIPTION
## Problem
`EditProfileCard.tsx` was sending a `POST` request to `/api/profile/update`,
but the API route only exports a `PATCH` handler. This caused a 405 Method
Not Allowed response, making profile updates silently fail.

## Fix
Changed `method: "POST"` to `method: "PATCH"` in `EditProfileCard.tsx` to
match the API route handler.

## Changes
- `app/profile/EditProfileCard.tsx` — 1 line changed

Fixes #59 
