### PR TITLE
Race fix

### DIFF
--- a/app/dashboard/CreateLinkId.tsx
+++ b/app/dashboard/CreateLinkId.tsx
@@ -96,7 +96,10 @@ export default function CreateLinkId() {
                                 />
                             </div>
 
-                            {available === true && (
+                            {checking && (
+                                <p className="text-sm text-muted-foreground">Checking...</p>
+                            )}
+                            {!checking && available === true && (
                                 <p className="text-sm text-green-500">
                                     Username available
                                 </p>

--- a/app/dashboard/CreateLinkId.tsx
+++ b/app/dashboard/CreateLinkId.tsx
@@ -18,20 +18,33 @@ export default function CreateLinkId() {
     const [checking, setChecking] = useState(false);
     const abortRef = useRef<AbortController | null>(null);
 
-    async function checkUsername(value: string) {
+    const checkUsername = useCallback(async (value: string) => {
         setUsername(value);
 
         if (value.length < 3) {
             setAvailable(null);
             setSuggestions([]);
+            setChecking(false);
             return;
         }
 
-        const res = await fetch(`/api/username/check?username=${value}`);
+        abortRef.current?.abort();
+        abortRef.current = new AbortController();
+        setChecking(true);
+
+        try {
+        const res = await fetch(`/api/username/check?username=${value}`, {
+            signal: abortRef.current.signal,
+        });
         const data = await res.json();
         setAvailable(data.available);
         setSuggestions(data.suggestions ?? []);
-    }
+        } catch (e) {
+        if ((e as Error).name !== "AbortError") throw e;
+        } finally {
+        setChecking(false);
+        }
+    }, []);
 
     async function createLinkId() {
         setLoading(true);

--- a/app/dashboard/CreateLinkId.tsx
+++ b/app/dashboard/CreateLinkId.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,6 +15,8 @@ export default function CreateLinkId() {
     const [available, setAvailable] = useState<null | boolean>(null);
     const [suggestions, setSuggestions] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
+    const [checking, setChecking] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
 
     async function checkUsername(value: string) {
         setUsername(value);


### PR DESCRIPTION
### Summary
Fixes a race condition in checkUsername where rapid typing fires multiple concurrent fetches to /api/username/check. Because responses can arrive out of order, a slow response for an earlier query could overwrite the correct available state for the current input value — showing the wrong availability to the user.

### Problem
Every keystroke fired an independent, unguarded fetch with no mechanism to discard superseded responses. On a slow connection, typing john quickly could cause the response for joh to arrive last, leaving the UI showing "Username already taken" for john even if it's free.

### Changes

- Added abortRef — an AbortController ref that cancels the previous in-flight request before each new one is issued
- Added checking state to suppress stale results rendering while a request is in-flight
- Wrapped checkUsername in useCallback for a stable function reference across renders
- Updated the availability indicator in JSX to show "Checking..." while in-flight and guard the green "available" text behind !checking

### Testing

- Open DevTools → Network → Slow 3G
- Type a username quickly (e.g. john)
- Confirm the UI shows "Checking..." while in-flight and only resolves to the correct availability for the final input value
- Confirm that switching back to a fast connection behaves normally

### Related Issue
Closes #56 

