### PR TITLE
feat: username history and vanity URL redirect (#42)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { ProfileCard } from "./ProfileCard";
@@ -86,7 +86,19 @@ export default async function PublicProfile({
         notFound();
     }
 
-    if (!user) notFound();
+    if (!user) {
+        // Check username history for redirect
+        const history = await prisma.usernameHistory.findUnique({
+            where: { previousUsername: username },
+            include: { user: { select: { username: true } } },
+        });
+
+        if (history?.user?.username) {
+            redirect(`/${history.user.username}`);
+        }
+
+        notFound();
+    }
 
     return (
         <main className="min-h-screen bg-muted/40 px-4 py-16">

--- a/app/api/profile/update/route.ts
+++ b/app/api/profile/update/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { validateUsername } from "@/lib/validations/username";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 export async function PATCH(req: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
     const body = await req.json();
-    const { username, userId, ...otherFields } = body;
+    const { username, ...otherFields } = body;
 
     if (username !== undefined) {
       const validation = validateUsername(username);
@@ -25,6 +32,36 @@ export async function PATCH(req: NextRequest) {
           { error: "Username already taken" },
           { status: 409 }
         );
+      }
+    }
+
+    // Save old username to history if username is changing
+    if (username !== undefined) {
+    const currentUser = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { username: true },
+    });
+
+    if (currentUser?.username && currentUser.username !== username) {
+     // Check if new username is a previously used one (prevent reuse)
+     const reserved = await prisma.usernameHistory.findUnique({
+      where: { previousUsername: username },
+     });
+
+    if (reserved) {
+      return NextResponse.json(
+        { error: "This username was previously used and is reserved." },
+        { status: 409 }
+      );
+    }
+
+       // Save old username to history
+      await prisma.usernameHistory.create({
+       data: {
+        previousUsername: currentUser.username,
+        userId,
+         },
+       });
       }
     }
 

--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -110,6 +110,12 @@ export default function EditProfileCard({
                         />
                     </div>
 
+                    {username !== initialUsername && (
+                        <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+                            ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
+                        </div>
+                    )}
+
                     <div className="space-y-1">
                         <Label>Bio</Label>
                         <textarea

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,16 +13,18 @@ model User {
   emailVerified DateTime?
   image         String?
 
-  password      String?  
+  password      String?
 
   username      String?  @unique
 
-  bio            String?  
+  bio            String?
 
   links         Link[]
   accounts      Account[]
   sessions      Session[]
   createdAt     DateTime @default(now())
+
+  usernameHistory UsernameHistory[]
 }
 
 
@@ -77,3 +79,11 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
+model UsernameHistory {
+  id               String   @id @default(cuid())
+  previousUsername String   @unique
+  userId           String
+  createdAt        DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}


### PR DESCRIPTION
Closes #42

## Changes Made
- **`prisma/schema.prisma`** — Added `UsernameHistory` model to track previous usernames
- **`app/[username]/page.tsx`** — Added redirect logic: if username not found, checks history and redirects to current username
- **`app/api/profile/update/route.ts`** — Before updating username, saves old username to `UsernameHistory`. Also prevents reuse of previously used usernames
- **`app/profile/EditProfileCard.tsx`** — Added warning banner when user tries to change username

## How to Test
1. Register a new account and set a username (e.g. `TestUser`)
2. Go to Profile settings and change username to something new (e.g. `TestUserNew`)
3. Notice the ⚠️ warning: *"Changing your username may affect existing shared links. Old links will automatically redirect to your new username."*
4. Save changes
5. Visit `localhost:3000/TestUser` (old username)
6. You will be automatically redirected to `localhost:3000/TestUserNew` ✅

## Checklist
- [x] Code follows project conventions
- [x] Self-reviewed the changes
- [x] No console.log left behind
- [x] No new TypeScript errors
- [x] Tested manually on desktop

## Organization
- [x] GSSoC 2026