### PR TITLE
[FEAT] Build Reliable Click Analytics Pipeline (Unique Visitors + Bot Filtering + Daily Aggregates)

### DIFF
--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -1,6 +1,8 @@
 import prisma from "@/lib/prisma";
 import { redirect, notFound } from "next/navigation";
+import { headers } from "next/headers";
 import { PlatformParams } from "../types/type";
+import { trackLinkClick } from "@/lib/analytics";
 
 export default async function PlatformRedirect({
     params,
@@ -8,15 +10,16 @@ export default async function PlatformRedirect({
     params: Promise<PlatformParams>;
 }) {
     const { username, platform } = await params;
+    const requestHeaders = await headers();
 
-    let link: { id: string; url: string } | null = null;
+    let link: { id: string; url: string; userId: string } | null = null;
     try {
         link = await prisma.link.findFirst({
             where: {
                 platform,
                 user: { username },
             },
-            select: { id: true, url: true },
+            select: { id: true, url: true, userId: true },
         });
     } catch {
         notFound();
@@ -26,9 +29,10 @@ export default async function PlatformRedirect({
         notFound();
     }
 
-    await prisma.link.update({
-        where: { id: link.id },
-        data: { clicks: { increment: 1 } },
+    await trackLinkClick({
+        linkId: link.id,
+        userId: link.userId,
+        headers: requestHeaders,
     });
 
     redirect(link.url);

--- a/app/api/analytics/aggregate/route.ts
+++ b/app/api/analytics/aggregate/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+import { recomputeDailyAnalyticsForDate } from "@/lib/analytics";
+
+function toUtcDateFromInput(raw: string): Date | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+    if (!match) return null;
+
+    const year = Number.parseInt(match[1], 10);
+    const month = Number.parseInt(match[2], 10);
+    const day = Number.parseInt(match[3], 10);
+
+    if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function utcDayShift(base: Date, shift: number): Date {
+    return new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate() + shift));
+}
+
+export async function POST(req: Request) {
+    const cronSecret = process.env.ANALYTICS_CRON_SECRET;
+
+    if (!cronSecret) {
+        return NextResponse.json(
+            { error: "ANALYTICS_CRON_SECRET is not configured" },
+            { status: 500 }
+        );
+    }
+
+    const receivedSecret = req.headers.get("x-analytics-secret");
+    if (!receivedSecret || receivedSecret !== cronSecret) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({} as Record<string, unknown>));
+
+    const daysBackInput = typeof body.daysBack === "number" ? body.daysBack : 1;
+    const daysBack = Math.max(1, Math.min(30, Math.floor(daysBackInput)));
+
+    let dateBase = utcDayShift(new Date(), -1);
+    if (typeof body.date === "string") {
+        const parsed = toUtcDateFromInput(body.date);
+        if (!parsed) {
+            return NextResponse.json(
+                { error: "date must be in YYYY-MM-DD format" },
+                { status: 400 }
+            );
+        }
+        dateBase = parsed;
+    }
+
+    const output: Array<{ date: string; rows: number }> = [];
+
+    for (let i = 0; i < daysBack; i += 1) {
+        const date = utcDayShift(dateBase, -i);
+        const result = await recomputeDailyAnalyticsForDate(date);
+        output.push({
+            date: date.toISOString().slice(0, 10),
+            rows: result.rows,
+        });
+    }
+
+    return NextResponse.json({
+        success: true,
+        recomputedDays: output.length,
+        dates: output,
+    });
+}

--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+import { getUserAnalyticsSummary } from "@/lib/analytics";
+
+export async function GET(request: NextRequest) {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.email) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+        where: { email: session.user.email },
+        select: { id: true },
+    });
+
+    if (!user) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const daysQuery = request.nextUrl.searchParams.get("days");
+    const days = daysQuery ? Number.parseInt(daysQuery, 10) : 30;
+
+    if (Number.isNaN(days) || days < 1 || days > 365) {
+        return NextResponse.json(
+            { error: "days must be between 1 and 365" },
+            { status: 400 }
+        );
+    }
+
+    const summary = await getUserAnalyticsSummary({
+        userId: user.id,
+        days,
+    });
+
+    return NextResponse.json({ summary });
+}

--- a/app/api/links/click/route.ts
+++ b/app/api/links/click/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { NextResponse } from "next/server";
+import { trackLinkClick } from "@/lib/analytics";
 
 export async function POST(req: Request) {
     const { username, platform } = await req.json();
@@ -8,9 +9,19 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Missing params" }, { status: 400 });
     }
 
-    await prisma.link.updateMany({
+    const link = await prisma.link.findFirst({
         where: { platform, user: { username } },
-        data: { clicks: { increment: 1 } },
+        select: { id: true, userId: true },
+    });
+
+    if (!link) {
+        return NextResponse.json({ error: "Link not found" }, { status: 404 });
+    }
+
+    await trackLinkClick({
+        linkId: link.id,
+        userId: link.userId,
+        headers: req.headers,
     });
 
     return NextResponse.json({ success: true });

--- a/app/dashboard/AnalyticsOverview.tsx
+++ b/app/dashboard/AnalyticsOverview.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type AnalyticsSummary = {
+    rangeDays: number;
+    totals: {
+        totalClicks: number;
+        uniqueClicks: number;
+        botClicks: number;
+    };
+};
+
+export function AnalyticsOverview() {
+    const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function loadSummary() {
+            try {
+                const response = await fetch("/api/analytics/summary?days=30");
+                if (!response.ok) return;
+
+                const payload = (await response.json()) as { summary?: AnalyticsSummary };
+                if (!cancelled && payload.summary) {
+                    setSummary(payload.summary);
+                }
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        void loadSummary();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const cards = useMemo(() => {
+        if (!summary) {
+            return [
+                { label: "Total Clicks", value: 0 },
+                { label: "Unique Visitors", value: 0 },
+                { label: "Filtered Bot Hits", value: 0 },
+            ];
+        }
+
+        return [
+            { label: "Total Clicks", value: summary.totals.totalClicks },
+            { label: "Unique Visitors", value: summary.totals.uniqueClicks },
+            { label: "Filtered Bot Hits", value: summary.totals.botClicks },
+        ];
+    }, [summary]);
+
+    return (
+        <section className="space-y-3">
+            <div>
+                <h2 className="text-lg font-semibold">Analytics (last 30 days)</h2>
+                <p className="text-sm text-muted-foreground">
+                    Bot traffic is filtered from totals and unique visitor counts.
+                </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                {cards.map((card) => (
+                    <Card key={card.label}>
+                        <CardHeader className="pb-2">
+                            <CardTitle className="text-sm font-medium text-muted-foreground">
+                                {card.label}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-2xl font-semibold">
+                                {loading ? "..." : card.value.toLocaleString()}
+                            </p>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -6,6 +6,7 @@ import toast, { Toaster } from "react-hot-toast";
 import { LinksSection } from "./LinksSection";
 import type { Link as ProfileLink } from "@/app/[username]/types/type";
 import { LinkIdCard } from "./LinkIdCard";
+import { AnalyticsOverview } from "./AnalyticsOverview";
 
 export default function DashboardClient({
     username,
@@ -116,6 +117,8 @@ export default function DashboardClient({
                 </section>
 
                 <LinkIdCard username={username} qrCode={qrCode} />
+
+                <AnalyticsOverview />
 
                 <LinksSection
                     username={username}

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { detectDeviceType, isLikelyBot } from "@/lib/analyticsUtils";
+
+test("isLikelyBot identifies common crawler user agents", () => {
+    assert.equal(isLikelyBot("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"), true);
+    assert.equal(isLikelyBot("Twitterbot/1.0"), true);
+});
+
+test("isLikelyBot treats normal browser user agents as non-bot", () => {
+    assert.equal(
+        isLikelyBot(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36"
+        ),
+        false
+    );
+});
+
+test("detectDeviceType classifies mobile, tablet and desktop", () => {
+    assert.equal(
+        detectDeviceType(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148"
+        ),
+        "mobile"
+    );
+
+    assert.equal(
+        detectDeviceType(
+            "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148"
+        ),
+        "tablet"
+    );
+
+    assert.equal(
+        detectDeviceType(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36"
+        ),
+        "desktop"
+    );
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,269 @@
+import prisma from "@/lib/prisma";
+import {
+    detectDeviceType,
+    getForwardedIp,
+    getVisitorKey,
+    isLikelyBot,
+    utcDayEndExclusive,
+    utcDayStart,
+} from "@/lib/analyticsUtils";
+
+const UNIQUE_VISITOR_WINDOW_HOURS = 24;
+
+type TrackClickInput = {
+    linkId: string;
+    userId: string;
+    headers: Headers;
+};
+
+export async function trackLinkClick(input: TrackClickInput): Promise<void> {
+    const { linkId, userId, headers } = input;
+
+    const userAgent = headers.get("user-agent");
+    const referrer = headers.get("referer") ?? headers.get("referrer");
+    const country = headers.get("x-vercel-ip-country") ?? headers.get("cf-ipcountry");
+    const acceptLanguage = headers.get("accept-language");
+    const ip = getForwardedIp(headers);
+    const isBot = isLikelyBot(userAgent);
+    const deviceType = detectDeviceType(userAgent);
+    const visitorKey = isBot
+        ? null
+        : getVisitorKey({
+              ip,
+              userAgent,
+              acceptLanguage,
+          });
+
+    const uniqueWindowStart = new Date(Date.now() - UNIQUE_VISITOR_WINDOW_HOURS * 60 * 60 * 1000);
+
+    const existingRecentClick = !isBot && visitorKey
+        ? await prisma.clickEvent.findFirst({
+              where: {
+                  linkId,
+                  visitorKey,
+                  isBot: false,
+                  createdAt: { gte: uniqueWindowStart },
+              },
+              select: { id: true },
+          })
+        : null;
+
+    const isUniqueVisitor = Boolean(!isBot && visitorKey && !existingRecentClick);
+    const today = utcDayStart(new Date());
+
+    await prisma.$transaction([
+        prisma.clickEvent.create({
+            data: {
+                linkId,
+                userId,
+                visitorKey,
+                userAgent,
+                referrer,
+                country,
+                deviceType,
+                isBot,
+                isUniqueVisitor,
+            },
+        }),
+        prisma.dailyLinkAnalytics.upsert({
+            where: {
+                linkId_date: {
+                    linkId,
+                    date: today,
+                },
+            },
+            update: {
+                totalClicks: { increment: isBot ? 0 : 1 },
+                uniqueClicks: { increment: isUniqueVisitor ? 1 : 0 },
+                botClicks: { increment: isBot ? 1 : 0 },
+            },
+            create: {
+                linkId,
+                userId,
+                date: today,
+                totalClicks: isBot ? 0 : 1,
+                uniqueClicks: isUniqueVisitor ? 1 : 0,
+                botClicks: isBot ? 1 : 0,
+            },
+        }),
+        prisma.link.update({
+            where: { id: linkId },
+            data: { clicks: { increment: isBot ? 0 : 1 } },
+        }),
+    ]);
+}
+
+export async function recomputeDailyAnalyticsForDate(date: Date): Promise<{ rows: number }> {
+    const start = utcDayStart(date);
+    const endExclusive = utcDayEndExclusive(date);
+
+    const events = await prisma.clickEvent.findMany({
+        where: {
+            createdAt: {
+                gte: start,
+                lt: endExclusive,
+            },
+        },
+        select: {
+            linkId: true,
+            userId: true,
+            isBot: true,
+            isUniqueVisitor: true,
+        },
+    });
+
+    const counters = new Map<
+        string,
+        {
+            linkId: string;
+            userId: string;
+            totalClicks: number;
+            uniqueClicks: number;
+            botClicks: number;
+        }
+    >();
+
+    for (const event of events) {
+        const key = event.linkId;
+        const current = counters.get(key) ?? {
+            linkId: event.linkId,
+            userId: event.userId,
+            totalClicks: 0,
+            uniqueClicks: 0,
+            botClicks: 0,
+        };
+
+        if (event.isBot) {
+            current.botClicks += 1;
+        } else {
+            current.totalClicks += 1;
+        }
+
+        if (event.isUniqueVisitor) {
+            current.uniqueClicks += 1;
+        }
+
+        counters.set(key, current);
+    }
+
+    const upserts = Array.from(counters.values()).map((entry) =>
+        prisma.dailyLinkAnalytics.upsert({
+            where: {
+                linkId_date: {
+                    linkId: entry.linkId,
+                    date: start,
+                },
+            },
+            update: {
+                userId: entry.userId,
+                totalClicks: entry.totalClicks,
+                uniqueClicks: entry.uniqueClicks,
+                botClicks: entry.botClicks,
+            },
+            create: {
+                linkId: entry.linkId,
+                userId: entry.userId,
+                date: start,
+                totalClicks: entry.totalClicks,
+                uniqueClicks: entry.uniqueClicks,
+                botClicks: entry.botClicks,
+            },
+        })
+    );
+
+    if (upserts.length > 0) {
+        await prisma.$transaction(upserts);
+    }
+
+    return { rows: upserts.length };
+}
+
+export async function getUserAnalyticsSummary(input: {
+    userId: string;
+    days: number;
+}) {
+    const days = Number.isFinite(input.days) ? Math.max(1, Math.min(365, input.days)) : 30;
+    const start = utcDayStart(new Date(Date.now() - (days - 1) * 24 * 60 * 60 * 1000));
+
+    const [totals, perLink] = await Promise.all([
+        prisma.dailyLinkAnalytics.aggregate({
+            where: {
+                userId: input.userId,
+                date: { gte: start },
+            },
+            _sum: {
+                totalClicks: true,
+                uniqueClicks: true,
+                botClicks: true,
+            },
+        }),
+        prisma.dailyLinkAnalytics.groupBy({
+            by: ["linkId"],
+            where: {
+                userId: input.userId,
+                date: { gte: start },
+            },
+            _sum: {
+                totalClicks: true,
+                uniqueClicks: true,
+                botClicks: true,
+            },
+        }),
+    ]);
+
+    if (perLink.length === 0) {
+        return {
+            rangeDays: days,
+            totals: {
+                totalClicks: 0,
+                uniqueClicks: 0,
+                botClicks: 0,
+            },
+            links: [],
+        };
+    }
+
+    const links = await prisma.link.findMany({
+        where: {
+            id: {
+                in: perLink.map((entry) => entry.linkId),
+            },
+        },
+        select: {
+            id: true,
+            platform: true,
+            label: true,
+            url: true,
+            isPublic: true,
+        },
+    });
+
+    const linksById = new Map(links.map((link) => [link.id, link]));
+
+    return {
+        rangeDays: days,
+        totals: {
+            totalClicks: totals._sum.totalClicks ?? 0,
+            uniqueClicks: totals._sum.uniqueClicks ?? 0,
+            botClicks: totals._sum.botClicks ?? 0,
+        },
+        links: perLink
+            .map((entry) => {
+                const link = linksById.get(entry.linkId);
+                if (!link) return null;
+
+                return {
+                    id: link.id,
+                    platform: link.platform,
+                    label: link.label,
+                    url: link.url,
+                    isPublic: link.isPublic,
+                    totalClicks: entry._sum.totalClicks ?? 0,
+                    uniqueClicks: entry._sum.uniqueClicks ?? 0,
+                    botClicks: entry._sum.botClicks ?? 0,
+                };
+            })
+            .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+            .sort((a, b) => b.totalClicks - a.totalClicks),
+    };
+}

--- a/lib/analyticsUtils.ts
+++ b/lib/analyticsUtils.ts
@@ -1,0 +1,53 @@
+import { createHash } from "node:crypto";
+
+const BOT_USER_AGENT_RE = /(bot|spider|crawler|bingpreview|slurp|duckduckbot|baiduspider|yandex|facebookexternalhit|twitterbot|whatsapp|telegrambot|discordbot|linkedinbot|headless|lighthouse)/i;
+
+export function getForwardedIp(headers: Headers): string | null {
+    const forwardedFor = headers.get("x-forwarded-for");
+    if (forwardedFor) {
+        const first = forwardedFor.split(",")[0]?.trim();
+        if (first) return first;
+    }
+
+    const realIp = headers.get("x-real-ip")?.trim();
+    return realIp || null;
+}
+
+export function isLikelyBot(userAgent: string | null | undefined): boolean {
+    if (!userAgent) return true;
+    return BOT_USER_AGENT_RE.test(userAgent);
+}
+
+export function detectDeviceType(userAgent: string | null | undefined): string {
+    if (!userAgent) return "unknown";
+
+    const normalized = userAgent.toLowerCase();
+    if (/ipad|tablet/i.test(normalized)) return "tablet";
+    if (/mobile|iphone|android(?!.*tablet)/i.test(normalized)) return "mobile";
+    return "desktop";
+}
+
+export function getVisitorKey(input: {
+    ip: string | null;
+    userAgent: string | null;
+    acceptLanguage: string | null;
+}): string | null {
+    const { ip, userAgent, acceptLanguage } = input;
+
+    if (!ip || !userAgent) {
+        return null;
+    }
+
+    const salt = process.env.ANALYTICS_VISITOR_KEY_SALT ?? "linkid-default-analytics-salt";
+    const raw = `${salt}|${ip}|${userAgent}|${acceptLanguage ?? ""}`;
+    return createHash("sha256").update(raw).digest("hex");
+}
+
+export function utcDayStart(date: Date): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function utcDayEndExclusive(date: Date): Date {
+    const start = utcDayStart(date);
+    return new Date(start.getTime() + 24 * 60 * 60 * 1000);
+}

--- a/lib/middleware/csrf.ts
+++ b/lib/middleware/csrf.ts
@@ -12,6 +12,7 @@ const CSRF_EXCLUDED_PATH_PREFIXES = [
     "/api/auth",
     "/api/csrf",
     "/api/links/click",
+    "/api/analytics/aggregate",
 ];
 
 export type CsrfDecision = "skip" | "allow" | "reject";

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "postinstall": "node scripts/postinstall-prisma-generate.mjs",
     "lint": "eslint",
-    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts"
+    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts lib/analytics.test.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/prisma/migrations/20260514121000_add_click_analytics_pipeline/migration.sql
+++ b/prisma/migrations/20260514121000_add_click_analytics_pipeline/migration.sql
@@ -1,0 +1,58 @@
+-- CreateTable
+CREATE TABLE "ClickEvent" (
+    "id" TEXT NOT NULL,
+    "linkId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "visitorKey" TEXT,
+    "userAgent" TEXT,
+    "referrer" TEXT,
+    "country" TEXT,
+    "deviceType" TEXT,
+    "isBot" BOOLEAN NOT NULL DEFAULT false,
+    "isUniqueVisitor" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ClickEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DailyLinkAnalytics" (
+    "id" TEXT NOT NULL,
+    "linkId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "totalClicks" INTEGER NOT NULL DEFAULT 0,
+    "uniqueClicks" INTEGER NOT NULL DEFAULT 0,
+    "botClicks" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DailyLinkAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ClickEvent_linkId_createdAt_idx" ON "ClickEvent"("linkId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ClickEvent_userId_createdAt_idx" ON "ClickEvent"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ClickEvent_linkId_visitorKey_createdAt_idx" ON "ClickEvent"("linkId", "visitorKey", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ClickEvent_createdAt_idx" ON "ClickEvent"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DailyLinkAnalytics_linkId_date_key" ON "DailyLinkAnalytics"("linkId", "date");
+
+-- CreateIndex
+CREATE INDEX "DailyLinkAnalytics_userId_date_idx" ON "DailyLinkAnalytics"("userId", "date");
+
+-- CreateIndex
+CREATE INDEX "DailyLinkAnalytics_date_idx" ON "DailyLinkAnalytics"("date");
+
+-- AddForeignKey
+ALTER TABLE "ClickEvent" ADD CONSTRAINT "ClickEvent_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DailyLinkAnalytics" ADD CONSTRAINT "DailyLinkAnalytics_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,9 +37,48 @@ model Link {
   isPublic  Boolean  @default(true)
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  clickEvents ClickEvent[]
+  dailyAnalytics DailyLinkAnalytics[]
   createdAt DateTime @default(now())
 
   @@unique([userId, platform])
+}
+
+model ClickEvent {
+  id              String   @id @default(uuid())
+  linkId           String
+  link             Link     @relation(fields: [linkId], references: [id], onDelete: Cascade)
+  userId           String
+  visitorKey       String?
+  userAgent        String?
+  referrer         String?
+  country          String?
+  deviceType       String?
+  isBot            Boolean  @default(false)
+  isUniqueVisitor  Boolean  @default(false)
+  createdAt        DateTime @default(now())
+
+  @@index([linkId, createdAt])
+  @@index([userId, createdAt])
+  @@index([linkId, visitorKey, createdAt])
+  @@index([createdAt])
+}
+
+model DailyLinkAnalytics {
+  id            String   @id @default(uuid())
+  linkId         String
+  link           Link     @relation(fields: [linkId], references: [id], onDelete: Cascade)
+  userId         String
+  date           DateTime
+  totalClicks    Int      @default(0)
+  uniqueClicks   Int      @default(0)
+  botClicks      Int      @default(0)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([linkId, date])
+  @@index([userId, date])
+  @@index([date])
 }
 model Account {
   id                String  @id @default(cuid())


### PR DESCRIPTION
## What this PR does

This PR implements the full analytics pipeline for profile/link engagement:

- Adds append-only click event tracking
- Adds daily aggregated analytics per link
- Filters likely bot traffic out of human click totals
- Tracks unique visitors using a 24-hour dedup window
- Keeps existing link clicks backward-compatible for current UI usage
- Adds secure aggregation endpoint for cron/scheduled recomputation
- Adds authenticated summary endpoint for dashboard consumption
- Adds dashboard analytics overview cards (Total, Unique, Filtered Bots)

## Why this change

Raw click incrementing alone is easy to inflate and cannot answer unique visitor questions.
This PR introduces a reliable analytics foundation with both real-time increments and recomputation support.

## Main changes

### 1) Database schema and migration

Added new models:
- ClickEvent
  - linkId, userId
  - visitorKey (hashed), userAgent, referrer
  - country, deviceType
  - isBot, isUniqueVisitor
  - createdAt
- DailyLinkAnalytics
  - linkId, userId, date
  - totalClicks, uniqueClicks, botClicks
  - createdAt, updatedAt

Also added indexes for fast time-window and per-link queries.

### 2) Shared analytics service

Created analytics service:
- trackLinkClick(...)
  - builds visitor key from IP + UA + language (hashed)
  - detects likely bots
  - computes unique visitor with 24h dedup
  - writes ClickEvent
  - upserts DailyLinkAnalytics for current UTC day
  - increments legacy Link.clicks only for non-bot clicks
- recomputeDailyAnalyticsForDate(...)
  - rebuilds a full day from raw events (idempotent upsert)
- getUserAnalyticsSummary(...)
  - returns totals and per-link aggregated metrics for a date range

Created analytics utility module for pure helpers:
- bot detection
- device detection
- forwarded IP extraction
- UTC day boundaries
- visitor key hashing

### 3) Redirect and click tracking integration

Updated redirect flow to use analytics pipeline:
- app/[username]/[platform]/page.tsx now calls trackLinkClick(...) before redirect

Updated legacy public click endpoint:
- app/api/links/click/route.ts now resolves link and uses trackLinkClick(...)

### 4) New analytics APIs

Added:
- GET /api/analytics/summary?days=30
  - requires authenticated user
  - returns totals + per-link summary
- POST /api/analytics/aggregate
  - intended for cron/internal jobs
  - protected by x-analytics-secret and ANALYTICS_CRON_SECRET
  - supports date and daysBack recomputation

### 5) Dashboard visibility

Added:
- AnalyticsOverview component on dashboard
  - shows last 30 days:
    - Total Clicks
    - Unique Visitors
    - Filtered Bot Hits

### 6) CSRF and tests

- Excluded /api/analytics/aggregate from CSRF checks (machine-to-machine call path)
- Added analytics unit tests:
  - bot detection
  - device classification

## Validation performed

- Prisma client regenerated successfully
- Tests passed:
  - 11 passed, 0 failed
- Lint passed with no errors
  - 1 pre-existing warning remains in AvatarCropModal image usage (unrelated to this PR)

## Environment notes

For cron aggregation endpoint, configure:

- ANALYTICS_CRON_SECRET=your-secret

## ISSUE RESOLVED #79 