### PR TITLE
fix(auth): prevent login API call when credentials fields are empty

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,143 +11,166 @@ import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 
 export default function LoginPage() {
-    const [email, setEmail] = useState("");
-    const [password, setPassword] = useState("");
-    const [showPassword, setShowPassword] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    async function handleLogin() {
-        setLoading(true);
-        setError(null);
+  async function handleLogin() {
+    const trimmedEmail = email.trim();
+    const trimmedPassword = password.trim();
 
-        const response = await signIn("credentials", {
-            email,
-            password,
-            callbackUrl: "/dashboard",
-            redirect: false,
-        });
+    if (!trimmedEmail.length || !trimmedPassword.length) {
+      setError("Please fill in both email and password.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
 
-        setLoading(false);
+    const response = await signIn("credentials", {
+      email: trimmedEmail,
+      password: trimmedPassword,
+      callbackUrl: "/dashboard",
+      redirect: false,
+    });
 
-        if (response?.error) {
-            setError("Login failed. Check your email and password.");
-            return;
-        }
+    setLoading(false);
 
-        if (response?.url) {
-            window.location.href = response.url;
-        }
+    if (response?.error) {
+      setError("Login failed. Check your email and password.");
+      return;
     }
 
-    return (
-        <>
-            <Navbar />
+    if (response?.url) {
+      window.location.href = response.url;
+    }
+  }
 
-            <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4">
-                <div className="w-full max-w-md space-y-3 rounded-xl border bg-background p-6 shadow-sm">
-                    {/* HEADER */}
-                    <div className="text-center space-y-1">
-                        <h1 className="text-2xl font-bold">Welcome back</h1>
-                        <p className="text-sm text-muted-foreground">
-                            Login to your LinkID
-                        </p>
-                    </div>
+  function isEmailAndPasswordEmpty() {
+    return !email.trim().length || !password.trim().length;
+  }
 
-                    {/* OAUTH */}
-                    <div className="space-y-2">
-                        <Button
-                            variant="outline"
-                            className="w-full flex items-center justify-center gap-2"
-                            onClick={() => signIn("google")}
-                        >
-                            <FcGoogle className="h-5 w-5" />
-                            Continue with Google
-                        </Button>
+  return (
+    <>
+      <Navbar />
 
-                        <Button
-                            variant="outline"
-                            className="w-full flex items-center justify-center gap-2"
-                            onClick={() => signIn("github")}
-                        >
-                            <FaGithub className="h-5 w-5" />
-                            Continue with GitHub
-                        </Button>
-                    </div>
+      <div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4">
+        <div className="w-full max-w-md space-y-3 rounded-xl border bg-background p-6 shadow-sm">
+          {/* HEADER */}
+          <div className="text-center space-y-1">
+            <h1 className="text-2xl font-bold">Welcome back</h1>
+            <p className="text-sm text-muted-foreground">
+              Login to your LinkID
+            </p>
+          </div>
 
-                    {/* DIVIDER */}
-                    <div className="flex items-center gap-2">
-                        <div className="h-px w-full bg-border" />
-                        <span className="text-xs text-muted-foreground">OR</span>
-                        <div className="h-px w-full bg-border" />
-                    </div>
+          {/* OAUTH */}
+          <div className="space-y-2">
+            <Button
+              variant="outline"
+              className="w-full flex items-center justify-center gap-2"
+              onClick={() => signIn("google")}
+            >
+              <FcGoogle className="h-5 w-5" />
+              Continue with Google
+            </Button>
 
-                    {/* FORM */}
-                    <div className="space-y-3">
-                        {error && (
-                            <p className="text-sm text-red-500" role="alert">
-                                {error}
-                            </p>
-                        )}
+            <Button
+              variant="outline"
+              className="w-full flex items-center justify-center gap-2"
+              onClick={() => signIn("github")}
+            >
+              <FaGithub className="h-5 w-5" />
+              Continue with GitHub
+            </Button>
+          </div>
 
-                        <Input
-                            type="email"
-                            placeholder="Email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                        />
+          {/* DIVIDER */}
+          <div className="flex items-center gap-2">
+            <div className="h-px w-full bg-border" />
+            <span className="text-xs text-muted-foreground">OR</span>
+            <div className="h-px w-full bg-border" />
+          </div>
 
-                        {/* PASSWORD WITH TOGGLE */}
-                        <div className="relative">
-                            <Input
-                                type={showPassword ? "text" : "password"}
-                                placeholder="Password"
-                                value={password}
-                                onChange={(e) => setPassword(e.target.value)}
-                                className="pr-10"
-                            />
+          {/* FORM */}
+          <form
+            className="space-y-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleLogin();
+            }}
+          >
+            {error && (
+              <p className="text-sm text-red-500" role="alert">
+                {error}
+              </p>
+            )}
 
-                            <button
-                                type="button"
-                                onClick={() => setShowPassword(!showPassword)}
-                                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                                aria-label={showPassword ? "Hide password" : "Show password"}
-                            >
-                                {showPassword ? (
-                                    <EyeOff className="h-4 w-4" />
-                                ) : (
-                                    <Eye className="h-4 w-4" />
-                                )}
-                            </button>
-                        </div>
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setError(null);
+              }}
+            />
 
-                        <div className="flex justify-end">
-                            <Link
-                                href="#"
-                                className="text-sm text-muted-foreground hover:underline"
-                            >
-                                Forgot password?
-                            </Link>
-                        </div>
+            {/* PASSWORD WITH TOGGLE */}
+            <div className="relative">
+              <Input
+                type={showPassword ? "text" : "password"}
+                placeholder="Password"
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setError(null);
+                }}
+                className="pr-10"
+              />
 
-                        <Button
-                            className="w-full"
-                            onClick={handleLogin}
-                            disabled={loading}
-                        >
-                            {loading ? "Logging in..." : "Login with Email"}
-                        </Button>
-                    </div>
-
-                    {/* FOOTER */}
-                    <p className="text-center text-sm text-muted-foreground">
-                        Don’t have an account?{" "}
-                        <Link href="/register" className="font-medium hover:underline">
-                            Signup
-                        </Link>
-                    </p>
-                </div>
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
             </div>
-        </>
-    );
+
+            <div className="flex justify-end">
+              <Link
+                href="#"
+                className="text-sm text-muted-foreground hover:underline"
+              >
+                Forgot password?
+              </Link>
+            </div>
+
+            <Button
+              className="w-full"
+              type="submit"
+              disabled={loading || isEmailAndPasswordEmpty()}
+            >
+              {loading ? "Logging in..." : "Login with Email"}
+            </Button>
+          </form>
+
+          {/* FOOTER */}
+          <p className="text-center text-sm text-muted-foreground">
+            Don’t have an account?{" "}
+            <Link href="/register" className="font-medium hover:underline">
+              Signup
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
## What does this PR do?

Prevents unnecessary login API requests when the email or password fields are empty.

The "Login with Email" button is now disabled until both required fields are filled, improving frontend validation and reducing unnecessary backend `401` responses.

---

## Related Issue

Closes #97 

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

---

## How to Test

1. Go to the Login page
2. Leave email and password fields empty
3. Verify that the "Login with Email" button is disabled
4. Enter valid values in both fields
5. Verify that the button becomes enabled
6. Open Network tab and confirm no unnecessary API call is made with empty fields

---

## Screenshots (if UI change)

<!-- Before / After screenshots -->
Before:

<img width="1029" height="746" alt="Screenshot from 2026-05-15 19-56-15" src="https://github.com/user-attachments/assets/24732cf6-50d7-474a-8b5d-5ad5013cf0a6" />

After:

<img width="1091" height="767" alt="Screenshot from 2026-05-16 09-30-56" src="https://github.com/user-attachments/assets/45a8ef63-a828-4f32-9fc4-a241478fbe57" />


---

## Checklist

- [x] Code follows project conventions
- [x] Self-reviewed the changes
- [x] No console.log left behind
- [x] No new TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email and password inputs are trimmed and required before attempting login.
  * Login is prevented with a clear "Please fill in both email and password." message when fields are empty.
  * Login button is disabled while a sign-in is in progress or when inputs are empty.
  * Loading state is set during sign-in and cleared afterward.
  * Existing error messages are cleared as the user types and before each login attempt.
  * Existing error and redirect behaviors remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->