### PR TITLE
feat: use oauth avatar as default

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,6 +7,28 @@ import type { NextAuthOptions } from "next-auth";
 
 import prisma from "@/lib/prisma";
 
+const oauthProviders = new Set(["google", "github"]);
+
+function getOAuthProfileImage(profile: unknown): string | null {
+    if (!profile || typeof profile !== "object") return null;
+
+    const data = profile as Record<string, unknown>;
+    const candidates = [
+        data.image,
+        data.picture,
+        data.avatar_url,
+        data.avatarUrl,
+    ];
+
+    for (const candidate of candidates) {
+        if (typeof candidate === "string" && candidate.trim().length > 0) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
 export const authOptions: NextAuthOptions = {
     adapter: PrismaAdapter(prisma),
 
@@ -66,9 +88,35 @@ export const authOptions: NextAuthOptions = {
     },
 
     callbacks: {
-        async jwt({ token, trigger, session, user }) {
+        async jwt({ token, trigger, session, user, account, profile }) {
             if (trigger === "update" && "image" in (session ?? {})) {
                 token.image = session.image ?? null;
+            }
+
+            if (account?.provider && oauthProviders.has(account.provider)) {
+                const oauthImage =
+                    getOAuthProfileImage(profile) ??
+                    (typeof user?.image === "string" ? user.image : null);
+
+                if (oauthImage) {
+                    const userId = user?.id ?? token.sub;
+                    if (userId) {
+                        const existing = await prisma.user.findUnique({
+                            where: { id: userId },
+                            select: { image: true },
+                        });
+
+                        if (!existing?.image) {
+                            await prisma.user.update({
+                                where: { id: userId },
+                                data: { image: oauthImage },
+                            });
+                            token.image = oauthImage;
+                        } else if (!token.image) {
+                            token.image = existing.image;
+                        }
+                    }
+                }
             }
             if (!token.image && user && "image" in user && user.image) {
                 token.image = user.image;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -102,19 +102,19 @@ export const authOptions: NextAuthOptions = {
                     const userId = user?.id ?? token.sub;
                     if (userId) {
                         try {
-                            const existing = await prisma.user.findUnique({
-                                where: { id: userId },
-                                select: { image: true },
+                            const result = await prisma.user.updateMany({
+                                where: { id: userId, image: null },
+                                data: { image: oauthImage },
                             });
 
-                            if (!existing?.image) {
-                                await prisma.user.update({
-                                    where: { id: userId },
-                                    data: { image: oauthImage },
-                                });
+                            if (result.count > 0) {
                                 token.image = oauthImage;
                             } else if (!token.image) {
-                                token.image = existing.image;
+                                const existing = await prisma.user.findUnique({
+                                    where: { id: userId },
+                                    select: { image: true },
+                                });
+                                token.image = existing?.image ?? null;
                             }
                         } catch (error) {
                             console.error("OAuth avatar sync failed", error);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -101,19 +101,23 @@ export const authOptions: NextAuthOptions = {
                 if (oauthImage) {
                     const userId = user?.id ?? token.sub;
                     if (userId) {
-                        const existing = await prisma.user.findUnique({
-                            where: { id: userId },
-                            select: { image: true },
-                        });
-
-                        if (!existing?.image) {
-                            await prisma.user.update({
+                        try {
+                            const existing = await prisma.user.findUnique({
                                 where: { id: userId },
-                                data: { image: oauthImage },
+                                select: { image: true },
                             });
-                            token.image = oauthImage;
-                        } else if (!token.image) {
-                            token.image = existing.image;
+
+                            if (!existing?.image) {
+                                await prisma.user.update({
+                                    where: { id: userId },
+                                    data: { image: oauthImage },
+                                });
+                                token.image = oauthImage;
+                            } else if (!token.image) {
+                                token.image = existing.image;
+                            }
+                        } catch (error) {
+                            console.error("OAuth avatar sync failed", error);
                         }
                     }
                 }


### PR DESCRIPTION
## organization
- [x] girlscript summer of code 2026 (gssoc'26)
- [ ] nexus spring of code 2026 (nsoc'26)
- [ ] none (general contribution)

## summary
set the user profile image from google or github oauth on first sign in when no custom image exists

## related issue
closes #117

## type of change
- [ ] 🐛 bug fix
- [x] ✨ new feature
- [ ] 🔗 new platform support
- [ ] ♻️ refactor (no feature or bug change)
- [ ] 📝 documentation update
- [ ] 🎨 ui / styling change
- [ ] 🔧 config / chore (deps, tooling, etc.)

## how to test
1. sign in with google or github on a fresh account
2. open the profile page and confirm the avatar shows the oauth image
3. upload a new avatar and confirm it replaces the oauth image

## screenshots

n/a

## checklist

**code quality**
- [x] my branch is up to date with `main`
- [x] `npm run lint` passes with no errors
- [x] `npm run build` completes successfully
- [x] no `console.log` statements left in the code
- [x] no new typescript errors introduced

**changes**
- [x] i have manually tested my changes in the browser
- [x] i tested on both desktop and mobile viewport
- [x] i tested in both light mode and dark mode (if ui change)
- [x] i tested edge cases (empty states, invalid inputs, long strings)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth avatar handling: provider profile images (e.g., Google, GitHub) are now automatically detected and saved to user accounts when no avatar exists, reducing missing-profile-image cases.
  * Preserves existing avatars and falls back to the current account/session image when provider image isn't available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->