### PR TITLE
feat: add date range filter dropdown to analytics section

### DIFF
--- a/app/api/analytics/summary/route.ts
+++ b/app/api/analytics/summary/route.ts
@@ -22,18 +22,23 @@ export async function GET(request: NextRequest) {
     }
 
     const daysQuery = request.nextUrl.searchParams.get("days");
-    const days = daysQuery ? Number.parseInt(daysQuery, 10) : 30;
+    const isAllTime = daysQuery === "all";
+    const days = isAllTime ? null : (daysQuery ? Number.parseInt(daysQuery, 10) : 30);
 
-    if (Number.isNaN(days) || days < 1 || days > 365) {
-        return NextResponse.json(
-            { error: "days must be between 1 and 365" },
-            { status: 400 }
-        );
+    if (!isAllTime) {
+        const numDays = days as number;
+
+        if (Number.isNaN(numDays) || numDays < 1 || numDays > 365) {
+            return NextResponse.json(
+                { error: "days must be between 1 and 365, or 'all'" },
+                { status: 400 }
+            );
+        }
     }
 
     const summary = await getUserAnalyticsSummary({
         userId: user.id,
-        days,
+        days,  // null = no date filter = all time
     });
 
     return NextResponse.json({ summary });

--- a/app/dashboard/AnalyticsOverview.tsx
+++ b/app/dashboard/AnalyticsOverview.tsx
@@ -3,9 +3,16 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 
 type AnalyticsSummary = {
-    rangeDays: number;
+    rangeDays: number | null ;
     totals: {
         totalClicks: number;
         uniqueClicks: number;
@@ -14,15 +21,17 @@ type AnalyticsSummary = {
 };
 
 export function AnalyticsOverview() {
+    const [days, setDays] = useState<"7" | "30" | "90" | "all">("30");
     const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         let cancelled = false;
+        setLoading(true);
 
         async function loadSummary() {
             try {
-                const response = await fetch("/api/analytics/summary?days=30");
+                const response = await fetch(`/api/analytics/summary?days=${days}`);
                 if (!response.ok) return;
 
                 const payload = (await response.json()) as { summary?: AnalyticsSummary };
@@ -41,7 +50,7 @@ export function AnalyticsOverview() {
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [days]);
 
     const cards = useMemo(() => {
         if (!summary) {
@@ -61,11 +70,24 @@ export function AnalyticsOverview() {
 
     return (
         <section className="space-y-3">
-            <div>
-                <h2 className="text-lg font-semibold">Analytics (last 30 days)</h2>
-                <p className="text-sm text-muted-foreground">
-                    Bot traffic is filtered from totals and unique visitor counts.
-                </p>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <h2 className="text-lg font-semibold">Analytics</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Bot traffic is filtered from totals and unique visitor counts.
+                    </p>
+                </div>
+                <Select value={days} onValueChange={(val) => { setDays(val as "7" | "30" | "90" | "all"); setLoading(true); }}>
+                    <SelectTrigger className="w-[160px]">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="7">Last 7 days</SelectItem>
+                        <SelectItem value="30">Last 30 days</SelectItem>
+                        <SelectItem value="90">Last 90 days</SelectItem>
+                        <SelectItem value="all">All time</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
 
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -113,7 +113,7 @@ export async function recomputeDailyAnalyticsForDate(date: Date): Promise<{ rows
     });
 
     const counters = new Map<
-        string,
+    string,
         {
             linkId: string;
             userId: string;
@@ -180,16 +180,21 @@ export async function recomputeDailyAnalyticsForDate(date: Date): Promise<{ rows
 
 export async function getUserAnalyticsSummary(input: {
     userId: string;
-    days: number;
+    days: number | null;
 }) {
-    const days = Number.isFinite(input.days) ? Math.max(1, Math.min(365, input.days)) : 30;
-    const start = utcDayStart(new Date(Date.now() - (days - 1) * 24 * 60 * 60 * 1000));
+    const rangeDays = input.days === null
+        ? null
+        : Math.max(1, Math.min(365, input.days));
+
+    const start = rangeDays === null
+        ? null
+        : utcDayStart(new Date(Date.now() - (rangeDays - 1) * 24 * 60 * 60 * 1000));
 
     const [totals, perLink] = await Promise.all([
         prisma.dailyLinkAnalytics.aggregate({
             where: {
                 userId: input.userId,
-                date: { gte: start },
+                ...(start !== null && { date: { gte: start } }),
             },
             _sum: {
                 totalClicks: true,
@@ -201,7 +206,7 @@ export async function getUserAnalyticsSummary(input: {
             by: ["linkId"],
             where: {
                 userId: input.userId,
-                date: { gte: start },
+                ...(start !== null && { date: { gte: start } }),
             },
             _sum: {
                 totalClicks: true,
@@ -213,7 +218,7 @@ export async function getUserAnalyticsSummary(input: {
 
     if (perLink.length === 0) {
         return {
-            rangeDays: days,
+            rangeDays,
             totals: {
                 totalClicks: 0,
                 uniqueClicks: 0,
@@ -241,7 +246,7 @@ export async function getUserAnalyticsSummary(input: {
     const linksById = new Map(links.map((link) => [link.id, link]));
 
     return {
-        rangeDays: days,
+        rangeDays,
         totals: {
             totalClicks: totals._sum.totalClicks ?? 0,
             uniqueClicks: totals._sum.uniqueClicks ?? 0,


### PR DESCRIPTION
## Summary
Added a date range filter dropdown to the Analytics section on the dashboard, allowing users to view analytics data across different time periods instead of being limited to the default 30-day view.

## Changes Made
- Added a dropdown filter next to the Analytics heading
- Added the following filter options:
  - Last 7 days
  - Last 30 days (default)
  - Last 90 days
  - All time
- Updated analytics state handling to respond to filter changes
- Updated API requests to pass selected date range parameters
- Updated analytics data rendering based on selected range

## Problem Solved
Previously, analytics data was hardcoded to display only the last 30 days, limiting visibility into short-term and long-term trends.

This update allows users to:
- Monitor short-term spikes
- Analyze medium-term trends
- View long-term performance growth


Fixes #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics Overview adds a time-range selector (7, 30, 90, All time); metrics refresh when a range is chosen.

* **Improvements**
  * Header text simplified to “Analytics”; metric cards show loading placeholders while data loads.
  * Server now supports an explicit All time option and clamps/validates numeric day requests (returns 400 for invalid values).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->