### PR TITLE
fix(Navlinks): Use root-hash Links so navbar anchors work from Login

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -6,9 +6,9 @@ import { ThemeToggle } from "@/app/components/ThemeToggle";
 import { Link2, Menu, X } from "lucide-react";
 
 const NAV_LINKS = [
-    { href: "#features", label: "Features", id: "features" },
-    { href: "#how", label: "How it works", id: "how" },
-    { href: "#demo", label: "Demo", id: "demo" },
+    { href: "/#features", label: "Features", id: "features" },
+    { href: "/#how", label: "How it works", id: "how" },
+    { href: "/#demo", label: "Demo", id: "demo" },
 ];
 
 export function Navbar() {
@@ -88,7 +88,7 @@ export function Navbar() {
                     {/* Desktop center nav */}
                     <nav className="hidden items-center gap-1 md:flex">
                         {NAV_LINKS.map(({ href, label, id }) => (
-                            <a
+                            <Link
                                 key={id}
                                 href={href}
                                 className={`relative rounded-full px-4 py-1.5 text-sm font-medium transition-colors duration-300
@@ -104,7 +104,7 @@ export function Navbar() {
                                 }`}
                             >
                                 {label}
-                            </a>
+                            </Link>
                         ))}
                     </nav>
 
@@ -143,7 +143,7 @@ export function Navbar() {
                     <div className="px-3 pb-4 pt-3">
                         <nav className="mb-3 flex flex-col gap-1">
                             {NAV_LINKS.map(({ href, label, id }) => (
-                                <a
+                                <Link
                                     key={id}
                                     href={href}
                                     onClick={() => setMobileOpen(false)}
@@ -154,7 +154,7 @@ export function Navbar() {
                                     }`}
                                 >
                                     {label}
-                                </a>
+                                </Link>
                             ))}
                         </nav>
                         <Button


### PR DESCRIPTION
## What does this PR do?

Fixes navbar anchor navigation so links (Features / How it works / Demo) work from any page (including Get Started / Login) by using root-hash URLs and Next.js [Link].

## Related Issue
Closes #180 

## Type of Change
- [ X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## How to Test
1. Start the dev server.
2. Open http://localhost:3000.
3. Click Get Started (or go to /login).
4. On the Login/Get Started page, click navbar links: Features, How it Works, and Demo.
5. Check that each link smoothly scrolls to the correct homepage section.
6. In mobile view, open the mobile menu and repeat the test.
Verify the mobile menu closes automatically after clicking a link.

## Screenshots (if UI change)

https://github.com/user-attachments/assets/9705eecb-5ca6-4997-be87-32544df8b35d


## Checklist
- [ x] Code follows project conventions
- [ x] Self-reviewed the changes
- [ x] No console.log left behind
- [ x] No new TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized navigation link handling for better performance and responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->