### PR TITLE
fix: fix broken footer links (#181)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -290,10 +290,11 @@ export default async function Home() {
               ["Get Started", "/login"],
             ]} />
             <FooterColumn title="Support" links={[
-["Report Issue", "https://github.com/your-repo/issues"],
- ["Community", "https://github.com/vishnukothakapu/linkid/discussions"],
-  ["Documentation", "/docs"],
-  ["Contact Us", "mailto:support@linkid.qzz.io"],            ]} />
+  ["Report Issue", "https://github.com/vishnukothakapu/linkid/issues"],
+  ["Community", "https://github.com/vishnukothakapu/linkid/discussions"],
+  ["Documentation", "https://github.com/vishnukothakapu/linkid#readme"],
+  ["Contact Us", "mailto:support@linkid.qzz.io"],
+]} />           
             <FooterColumn title="Company" links={[
               ["About", "/about"],
               ["Privacy Policy", "/privacy"],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -275,11 +275,10 @@ export default async function Home() {
               ["Get Started", "/login"],
             ]} />
             <FooterColumn title="Support" links={[
-              ["Report Issue", "https://github.com/your-repo/issues"],
-              ["Community", "https://github.com/your-repo/discussions"],
-              ["Documentation", "/docs"],
-              ["Contact Us", "mailto:support@linkid.qzz.io"],
-            ]} />
+["Report Issue", "https://github.com/your-repo/issues"],
+ ["Community", "https://github.com/vishnukothakapu/linkid/discussions"],
+  ["Documentation", "/docs"],
+  ["Contact Us", "mailto:support@linkid.qzz.io"],            ]} />
             <FooterColumn title="Company" links={[
               ["About", "/about"],
               ["Privacy Policy", "/privacy"],


### PR DESCRIPTION
## Description
Fixes broken links in the footer section.

## Changes Made
- Fixed Report Issue link to point to GitHub Issues
- Fixed Community link to point to GitHub Discussions
- Fixed Documentation link to point to GitHub README
- Fixed GitHub social icon link

## Related Issue
Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Support footer links: "Documentation" now points to the external GitHub README; "Report Issue", "Community", and "Contact Us" remain unchanged.

* **Style**
  * Minor footer formatting adjustments for consistent link presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->