### PR TITLE
feat: add loading spinner on Google and GitHub OAuth buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL="postgresql://postgres:gpnashik8485@localhost:5432/linkid"
+DATABASE_URL="postgresql://user:password@localhost:5432/linkid"
 
 # NextAuth
 NEXTAUTH_SECRET="your-secret-here"          # openssl rand -base64 32

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL="postgresql://user:password@localhost:5432/linkid"
+DATABASE_URL="postgresql://postgres:gpnashik8485@localhost:5432/linkid"
 
 # NextAuth
 NEXTAUTH_SECRET="your-secret-here"          # openssl rand -base64 32

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -74,7 +74,7 @@ export default function LoginPage() {
             <Button
               variant="outline"
               className="w-full flex items-center justify-center gap-2"
-              disabled={googleLoading}
+              disabled={googleLoading || githubLoading}
               onClick={async () => {
                 setGoogleLoading(true);
                 try {
@@ -91,7 +91,7 @@ export default function LoginPage() {
             <Button
               variant="outline"
               className="w-full flex items-center justify-center gap-2"
-              disabled={githubLoading}
+              disabled={googleLoading || githubLoading}
               onClick={async () => {
                 setGithubLoading(true);
                 try {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 import { useState } from "react";
 import { Navbar } from "../components/Navbar";
 import { FcGoogle } from "react-icons/fc";
@@ -76,17 +77,14 @@ export default function LoginPage() {
               disabled={googleLoading}
               onClick={async () => {
                 setGoogleLoading(true);
-                await signIn("google", { callbackUrl: "/dashboard" });
+                try {
+                  await signIn("google", { callbackUrl: "/dashboard" });
+                } finally {
+                  setGoogleLoading(false);
+                }
               }}
             >
-              {googleLoading ? (
-                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                </svg>
-              ) : (
-                <FcGoogle className="h-5 w-5" />
-              )}
+              {googleLoading ? <Spinner className="h-5 w-5" /> : <FcGoogle className="h-5 w-5" />}
               {googleLoading ? "Connecting..." : "Continue with Google"}
             </Button>
 
@@ -96,17 +94,14 @@ export default function LoginPage() {
               disabled={githubLoading}
               onClick={async () => {
                 setGithubLoading(true);
-                await signIn("github", { callbackUrl: "/dashboard" });
+                try {
+                  await signIn("github", { callbackUrl: "/dashboard" });
+                } finally {
+                  setGithubLoading(false);
+                }
               }}
             >
-              {githubLoading ? (
-                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                </svg>
-              ) : (
-                <FaGithub className="h-5 w-5" />
-              )}
+              {githubLoading ? <Spinner className="h-5 w-5" /> : <FaGithub className="h-5 w-5" />}
               {githubLoading ? "Connecting..." : "Continue with GitHub"}
             </Button>
           </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,6 +17,9 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [githubLoading, setGithubLoading] = useState(false);
+
   async function handleLogin() {
     const trimmedEmail = email.trim();
     const trimmedPassword = password.trim();
@@ -70,19 +73,41 @@ export default function LoginPage() {
             <Button
               variant="outline"
               className="w-full flex items-center justify-center gap-2"
-              onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
+              disabled={googleLoading}
+              onClick={async () => {
+                setGoogleLoading(true);
+                await signIn("google", { callbackUrl: "/dashboard" });
+              }}
             >
-              <FcGoogle className="h-5 w-5" />
-              Continue with Google
+              {googleLoading ? (
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                </svg>
+              ) : (
+                <FcGoogle className="h-5 w-5" />
+              )}
+              {googleLoading ? "Connecting..." : "Continue with Google"}
             </Button>
 
             <Button
               variant="outline"
               className="w-full flex items-center justify-center gap-2"
-              onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
+              disabled={githubLoading}
+              onClick={async () => {
+                setGithubLoading(true);
+                await signIn("github", { callbackUrl: "/dashboard" });
+              }}
             >
-              <FaGithub className="h-5 w-5" />
-              Continue with GitHub
+              {githubLoading ? (
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                </svg>
+              ) : (
+                <FaGithub className="h-5 w-5" />
+              )}
+              {githubLoading ? "Connecting..." : "Continue with GitHub"}
             </Button>
           </div>
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -95,7 +95,7 @@ export default function RegisterPage() {
                         <Button
                             variant="outline"
                             className="flex w-full items-center justify-center gap-2"
-                            disabled={googleLoading}
+                            disabled={googleLoading || githubLoading}
                             onClick={async () => {
                                 setGoogleLoading(true);
                                 try {
@@ -112,7 +112,7 @@ export default function RegisterPage() {
                         <Button
                             variant="outline"
                             className="flex w-full items-center justify-center gap-2"
-                            disabled={githubLoading}
+                            disabled={googleLoading || githubLoading}
                             onClick={async () => {
                                 setGithubLoading(true);
                                 try {

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -10,6 +10,7 @@ import { FcGoogle } from "react-icons/fc";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 import { getCsrfToken } from "@/lib/csrfClient";
 import { useCsrf } from "@/lib/useCsrf";
 
@@ -97,17 +98,14 @@ export default function RegisterPage() {
                             disabled={googleLoading}
                             onClick={async () => {
                                 setGoogleLoading(true);
-                                await signIn("google", { callbackUrl: "/dashboard" });
+                                try {
+                                    await signIn("google", { callbackUrl: "/dashboard" });
+                                } finally {
+                                    setGoogleLoading(false);
+                                }
                             }}
                         >
-                            {googleLoading ? (
-                                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
-                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                                </svg>
-                            ) : (
-                                <FcGoogle className="h-5 w-5" />
-                            )}
+                            {googleLoading ? <Spinner className="h-5 w-5" /> : <FcGoogle className="h-5 w-5" />}
                             {googleLoading ? "Connecting..." : "Continue with Google"}
                         </Button>
 
@@ -117,18 +115,17 @@ export default function RegisterPage() {
                             disabled={githubLoading}
                             onClick={async () => {
                                 setGithubLoading(true);
-                                await signIn("github", { callbackUrl: "/dashboard" });
+                                try {
+                                    await signIn("github", { callbackUrl: "/dashboard" });
+                                } finally {
+                                    setGithubLoading(false);
+                                }
                             }}
                         >
-                            {githubLoading ? (
-                                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
-                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                                </svg>
-                            ) : (
-                                <FaGithub className="h-5 w-5" />
-                            )}
+
+                            {githubLoading ? <Spinner className="h-5 w-5" /> : <FaGithub className="h-5 w-5" />}
                             {githubLoading ? "Connecting..." : "Continue with GitHub"}
+
                         </Button>
                     </div>
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -23,6 +23,9 @@ export default function RegisterPage() {
     const [submitError, setSubmitError] = useState<string | null>(null);
     const csrfToken = useCsrf();
 
+    const [googleLoading, setGoogleLoading] = useState(false);
+    const [githubLoading, setGithubLoading] = useState(false);
+
     const getPasswordError = (value: string) => {
         if (value.length < 8) return "Must be at least 8 characters";
         if (!/[A-Z]/.test(value)) return "Must include one uppercase letter";
@@ -91,19 +94,41 @@ export default function RegisterPage() {
                         <Button
                             variant="outline"
                             className="flex w-full items-center justify-center gap-2"
-                            onClick={() => signIn("google", { callbackUrl: "/dashboard" })}
+                            disabled={googleLoading}
+                            onClick={async () => {
+                                setGoogleLoading(true);
+                                await signIn("google", { callbackUrl: "/dashboard" });
+                            }}
                         >
-                            <FcGoogle className="h-5 w-5" />
-                            Continue with Google
+                            {googleLoading ? (
+                                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                                </svg>
+                            ) : (
+                                <FcGoogle className="h-5 w-5" />
+                            )}
+                            {googleLoading ? "Connecting..." : "Continue with Google"}
                         </Button>
 
                         <Button
                             variant="outline"
                             className="flex w-full items-center justify-center gap-2"
-                            onClick={() => signIn("github", { callbackUrl: "/dashboard" })}
+                            disabled={githubLoading}
+                            onClick={async () => {
+                                setGithubLoading(true);
+                                await signIn("github", { callbackUrl: "/dashboard" });
+                            }}
                         >
-                            <FaGithub className="h-5 w-5" />
-                            Continue with GitHub
+                            {githubLoading ? (
+                                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                                </svg>
+                            ) : (
+                                <FaGithub className="h-5 w-5" />
+                            )}
+                            {githubLoading ? "Connecting..." : "Continue with GitHub"}
                         </Button>
                     </div>
 

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,8 +1,7 @@
-import { Loader2Icon } from "lucide-react"
-
+import { Loader2Icon, type LucideProps } from "lucide-react"
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: LucideProps) {
   return (
     <Loader2Icon
       role="status"

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,7 +182,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -443,8 +442,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
       "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.6",
@@ -1975,7 +1973,6 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.2.0.tgz",
       "integrity": "sha512-JdLF8lWZ+LjKGKpBqyAlenxd/kXjd1Abf/xK+6vUA7R7L2Suo6AFTHFRpPSdAKCan9wzdFApsUpSa/F6+t1AtA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/client-runtime-utils": "7.2.0"
       },
@@ -4219,7 +4216,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4230,7 +4226,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4301,7 +4296,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -4807,7 +4801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5268,7 +5261,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5645,8 +5637,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6194,7 +6185,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6380,7 +6370,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7222,7 +7211,6 @@
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8680,7 +8668,6 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
       "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -9058,7 +9045,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9303,7 +9289,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9344,7 +9329,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.2.0",
         "@prisma/dev": "0.17.0",
@@ -9522,7 +9506,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9532,7 +9515,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10556,7 +10538,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10785,7 +10766,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11329,7 +11309,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## What's changed

Added loading states for the Google and GitHub auth buttons on both `/login` and `/register`.

### Improvements made

* Added a loading spinner while OAuth authentication starts
* Disabled auth buttons during redirect to prevent multiple clicks
* Updated button text to `Connecting...` while processing
* Added separate loading handling for each provider button

## Files changed

* `app/login/page.tsx`
* `app/register/page.tsx`

## Screenshots

### Loading state

<img width="976" height="543" alt="Screenshot 2026-05-23 000331" src="https://github.com/user-attachments/assets/4a24ab27-61af-4a67-9437-33dcd33e76bf" />

## Related issue

Closes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading indicators with "Connecting..." text to OAuth sign-in buttons on login and register pages
  * OAuth buttons are now disabled during authentication to prevent accidental duplicate sign-in requests
  * Improved visual feedback during the authentication process on both Google and GitHub sign-in flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->