### PR TITLE
fix: accept twitter.com URLs for X platform validation

### DIFF
--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -19,7 +19,7 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     linkedin: /^https?:\/\/(www\.)?linkedin\.com\/(in|company)\/[^/]+/i,
     leetcode: /^https?:\/\/(www\.)?leetcode\.com\/[^/]+/i,
     youtube: /^https?:\/\/(www\.)?youtube\.com\/[^/]+/i,
-    x: /^https?:\/\/(www\.)?x\.com\/[^/]+/i,
+    x: /^https?:\/\/(www\.)?(x|twitter)\.com\/[^/]+/i,
     facebook: /^https?:\/\/(www\.)?facebook\.com\/[^/]+/i,
     instagram: /^https?:\/\/(www\.)?instagram\.com\/[^/]+/i,
     discord: /^https?:\/\/(www\.)?discord\.com\/users\/[^/]+/i,


### PR DESCRIPTION
## What This PR Fixes

This PR fixes validation for the **X (Twitter)** platform by allowing both `x.com` and legacy `twitter.com` profile URLs.

Previously, URLs using the `twitter.com` domain were rejected with:

> Please enter a valid public link.

even when the selected platform was **X (Twitter)**.

---

## Changes Made

- Updated platform validation logic in `lib/platforms.ts`
- Added support for `twitter.com` URL detection
- Extended `validatePlatformUrl` compatibility
- Ensured API routes accept both domains:
  - `app/api/links/route.ts`
  - `app/api/links/[id]/route.ts`

---

## Tested

Tested with the following URLs:

- https://x.com/<username>
- https://twitter.com/<username>

Both URLs now validate and save successfully.

---

## 📎 Additional Notes

This maintains backward compatibility for users still using legacy Twitter profile URLs while supporting the current X branding.

Issue #231 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended platform URL recognition to support both x.com and twitter.com domains for improved link compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->