### PR TITLE
fix: prevent access to private links via public routes

### DIFF
--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -22,6 +22,7 @@ export default async function PlatformRedirect({
         where: {
             platform,
             userId: resolved.user.id,
+            isPublic: true,
         },
         select: { id: true, url: true, userId: true },
     });


### PR DESCRIPTION
## What This PR Fixes

This PR fixes a privacy issue where links marked as **Private** could still be accessed directly through public routes like:

https://linkid.qzz.io/<username>/<platform>

Previously, the route handler fetched links without verifying whether the link was public, allowing hidden links to remain accessible and continue tracking clicks.

---

## Changes Made

- Updated public link lookup logic in:

  - `app/[username]/[platform]/page.tsx`

- Added visibility filtering using:

```ts
isPublic: true
```

- Prevented private links from:
  - Resolving publicly
  - Redirecting users
  - Tracking clicks

---

## Tested

Verified the following behavior:

### Public Links
- Continue redirecting normally
- Click tracking still works

### Private Links
- No longer resolve publicly
- Return a 404 / not found response
- Do not track clicks

---

## Additional Notes

This change aligns public route behavior with other public-facing surfaces that already respect the `isPublic` flag and closes a privacy/security loophole.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform redirect to only access public links. Private links are no longer accessible through platform redirects, ensuring proper access control and security.

Issue #233 
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->