### PR TITLE
Implement Smart Intent Routing (Deep Linking) for Mobile Users

### DIFF
--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { PlatformParams } from "../types/type";
 import { trackLinkClick } from "@/lib/analytics";
 import { resolveUserByUsername } from "@/lib/userLookup";
+import { getMobileOS, getDeepLink } from "@/lib/deeplink";
 
 export default async function PlatformRedirect({
     params,
@@ -14,9 +15,7 @@ export default async function PlatformRedirect({
     const requestHeaders = await headers();
 
     const resolved = await resolveUserByUsername(username);
-    if (!resolved) {
-        notFound();
-    }
+    if (!resolved) notFound();
 
     const link = await prisma.link.findFirst({
         where: {
@@ -35,5 +34,64 @@ export default async function PlatformRedirect({
         headers: requestHeaders,
     });
 
+    // --- Smart Intent Routing ---
+    const userAgent = requestHeaders.get("user-agent") ?? "";
+    const os = getMobileOS(userAgent);
+
+    if (os !== "unknown") {
+        const deepLinks = getDeepLink(platform, link.url);
+        const appUrl = os === "android" ? deepLinks.android : deepLinks.ios;
+
+        if (appUrl) {
+            const webUrl = link.url;
+            return (
+                <html lang="en">
+                    <head>
+                        <title>Opening {platform}...</title>
+                        <meta httpEquiv="refresh" content={`3;url=${webUrl}`} />
+                        <meta name="robots" content="noindex" />
+                        <style>{`
+                            body {
+                                font-family: sans-serif;
+                                display: flex;
+                                flex-direction: column;
+                                align-items: center;
+                                justify-content: center;
+                                min-height: 100vh;
+                                margin: 0;
+                                background: #0a0a0a;
+                                color: #e5e5e5;
+                            }
+                            p { font-size: 1rem; color: #888; margin-top: 12px; }
+                            a { color: #888; font-size: 0.85rem; margin-top: 24px; }
+                        `}</style>
+                    </head>
+                    <body>
+                        <script
+                            dangerouslySetInnerHTML={{
+                                __html: `
+                                    (function () {
+                                        var appUrl = ${JSON.stringify(appUrl)};
+                                        var webUrl = ${JSON.stringify(webUrl)};
+                                        var timer = setTimeout(function () {
+                                            window.location.replace(webUrl);
+                                        }, 2000);
+                                        window.addEventListener("visibilitychange", function () {
+                                            if (document.hidden) clearTimeout(timer);
+                                        });
+                                        window.location.href = appUrl;
+                                    })();
+                                `,
+                            }}
+                        />
+                        <p>Opening {platform} app...</p>
+                        <a href={webUrl}>Open in browser instead</a>
+                    </body>
+                </html>
+            );
+        }
+    }
+
+    // Desktop or no deep link available — plain redirect
     redirect(link.url);
 }

--- a/lib/deeplinks.ts
+++ b/lib/deeplinks.ts
@@ -1,0 +1,115 @@
+// lib/deeplink.ts
+
+export type Platform =
+  | "instagram"
+  | "youtube"
+  | "x"
+  | "twitter"
+  | "github"
+  | "linkedin"
+  | "facebook"
+  | "twitch"
+  | "discord"
+  | "tiktok";
+
+/**
+ * Detects if a User-Agent string belongs to Android or iOS.
+ */
+export function getMobileOS(userAgent: string): "android" | "ios" | "unknown" {
+  if (/android/i.test(userAgent)) return "android";
+  if (/iphone|ipad|ipod/i.test(userAgent)) return "ios";
+  return "unknown";
+}
+
+/**
+ * Given a web URL and a platform name, returns the deep link URI
+ * (custom app scheme) for Android/iOS if supported, else returns null.
+ *
+ * Examples:
+ *   instagram.com/p/abc → instagram://media?id=abc  (simplified)
+ *   youtube.com/watch?v=XYZ → vnd.youtube://XYZ
+ */
+export function getDeepLink(
+  platform: string,
+  webUrl: string
+): { android: string | null; ios: string | null } {
+  try {
+    const url = new URL(webUrl);
+    const path = url.pathname; // e.g. /reels/abc123
+
+    switch (platform.toLowerCase()) {
+      case "instagram": {
+        // instagram://user?username=USERNAME
+        const igUser = path.replace(/^\//, "").split("/")[0];
+        const appLink = igUser
+          ? `instagram://user?username=${igUser}`
+          : "instagram://";
+        return { android: appLink, ios: appLink };
+      }
+
+      case "youtube": {
+        // Channel: youtube.com/@handle or /channel/ID
+        // Video:   youtube.com/watch?v=VIDEO_ID
+        const videoId = url.searchParams.get("v");
+        if (videoId) {
+          return {
+            android: `vnd.youtube://${videoId}`,
+            ios: `vnd.youtube://${videoId}`,
+          };
+        }
+        const channelHandle = path.replace(/^\/@?/, "").split("/")[0];
+        return {
+          android: `vnd.youtube://www.youtube.com${path}`,
+          ios: `vnd.youtube://www.youtube.com${path}`,
+        };
+      }
+
+      case "x":
+      case "twitter": {
+        // twitter://user?screen_name=USERNAME
+        const handle = path.replace(/^\//, "").split("/")[0];
+        if (handle) {
+          const appLink = `twitter://user?screen_name=${handle}`;
+          return { android: appLink, ios: appLink };
+        }
+        return { android: "twitter://", ios: "twitter://" };
+      }
+
+      case "linkedin": {
+        // linkedin://in/USERNAME (iOS) | intent://linkedin.com/in/USERNAME (Android)
+        const liPath = path; // e.g. /in/vishnukothakapu
+        return {
+          android: `intent://linkedin.com${liPath}#Intent;package=com.linkedin.android;scheme=https;end`,
+          ios: `linkedin://${liPath}`,
+        };
+      }
+
+      case "facebook": {
+        const fbPath = path.replace(/^\//, "").split("/")[0];
+        return {
+          android: `fb://facewebmodal/f?href=${encodeURIComponent(webUrl)}`,
+          ios: `fb://profile`,
+        };
+      }
+
+      case "twitch": {
+        const channel = path.replace(/^\//, "").split("/")[0];
+        if (channel) {
+          const appLink = `twitch://stream/${channel}`;
+          return { android: appLink, ios: appLink };
+        }
+        return { android: null, ios: null };
+      }
+
+      case "tiktok": {
+        // TikTok deep links are restricted; fallback to web
+        return { android: null, ios: null };
+      }
+
+      default:
+        return { android: null, ios: null };
+    }
+  } catch {
+    return { android: null, ios: null };
+  }
+}

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -14,28 +14,98 @@ export type Platform =
     | "dribbble"
     | "website";
 
+// ─── URL Validation Patterns ─────────────────────────────────────────────────
+
 const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
-    github: /^https?:\/\/(www\.)?github\.com\/[^/]+/i,
-    linkedin: /^https?:\/\/(www\.)?linkedin\.com\/(in|company)\/[^/]+/i,
-    leetcode: /^https?:\/\/(www\.)?leetcode\.com\/[^/]+/i,
-    youtube: /^https?:\/\/(www\.)?youtube\.com\/[^/]+/i,
-    x: /^https?:\/\/(www\.)?x\.com\/[^/]+/i,
-    facebook: /^https?:\/\/(www\.)?facebook\.com\/[^/]+/i,
-    instagram: /^https?:\/\/(www\.)?instagram\.com\/[^/]+/i,
-    discord: /^https?:\/\/(www\.)?discord\.com\/users\/[^/]+/i,
-    twitch: /^https?:\/\/(www\.)?twitch\.tv\/[^/]+/i,
-    hashnode: /^https?:\/\/([^/]+\.)?hashnode\.(com|dev)(\/[^/]+)?/i,
-    devto: /^https?:\/\/(www\.)?dev\.to\/[^/]+/i,
-    medium: /^https?:\/\/(www\.)?medium\.com\/@?[^/]+/i,
-    dribbble: /^https?:\/\/(www\.)?dribbble\.com\/[^/]+/i,
-    website: /^https?:\/\/.+/i,
+    github:    /^https?:\/\/(www\.)?github\.com\/[A-Za-z0-9_.-]+\/?$/i,
+    linkedin:  /^https?:\/\/(www\.)?linkedin\.com\/(in|company)\/[A-Za-z0-9_-]+\/?$/i,
+    leetcode:  /^https?:\/\/(www\.)?leetcode\.com\/u\/[A-Za-z0-9_-]+\/?$/i,
+    youtube:   /^https?:\/\/(www\.)?youtube\.com\/(@[A-Za-z0-9_.-]+|channel\/[A-Za-z0-9_-]+|c\/[A-Za-z0-9_-]+)\/?$/i,
+    x:         /^https?:\/\/(www\.)?x\.com\/[A-Za-z0-9_]{1,15}\/?$/i,
+    facebook:  /^https?:\/\/(www\.)?facebook\.com\/(?!messaging|feed|groups|events)[A-Za-z0-9._-]+\/?$/i,
+    instagram: /^https?:\/\/(www\.)?instagram\.com\/[A-Za-z0-9._]{1,30}\/?$/i,
+    discord:   /^https?:\/\/(www\.)?discord\.com\/users\/\d{17,20}\/?$/i,
+    twitch:    /^https?:\/\/(www\.)?twitch\.tv\/[A-Za-z0-9_]{4,25}\/?$/i,
+    hashnode:  /^https?:\/\/([A-Za-z0-9_-]+\.hashnode\.(com|dev)|hashnode\.(com|dev)\/[A-Za-z0-9_@-]+)\/?$/i,
+    devto:     /^https?:\/\/(www\.)?dev\.to\/[A-Za-z0-9_-]+\/?$/i,
+    medium:    /^https?:\/\/(www\.)?medium\.com\/@[A-Za-z0-9_.-]+\/?$/i,
+    dribbble:  /^https?:\/\/(www\.)?dribbble\.com\/[A-Za-z0-9_-]+\/?$/i,
+    website:   /^https?:\/\/.+/i,
 };
 
-export function normalizeUrl(url: string) {
+// Blocks that indicate non-profile/spam URLs for specific platforms
+const PLATFORM_BLOCKLIST: Partial<Record<Platform, RegExp>> = {
+    linkedin:  /\/(messaging|feed|jobs|notifications|search)\//i,
+    facebook:  /\/(messaging|feed|groups|events|marketplace)\//i,
+    youtube:   /\/(watch|playlist|shorts|results)\b/i,
+    instagram: /\/(p|reel|explore|stories)\//i,
+};
+
+// ─── Deep Link Schemes ────────────────────────────────────────────────────────
+
+export type DeepLinkResult = { android: string | null; ios: string | null };
+
+/**
+ * Maps a platform + web URL to native app URI schemes.
+ * Returns null for platforms that don't support reliable deep linking.
+ */
+const DEEP_LINK_BUILDERS: Partial
+    Record<Platform, (url: URL) => DeepLinkResult>
+> = {
+    instagram: (url) => {
+        const username = url.pathname.replace(/^\/|\/$/g, "").split("/")[0];
+        if (!username) return { android: null, ios: null };
+        const scheme = `instagram://user?username=${username}`;
+        return { android: scheme, ios: scheme };
+    },
+
+    youtube: (url) => {
+        const videoId = url.searchParams.get("v");
+        if (videoId) {
+            const scheme = `vnd.youtube://${videoId}`;
+            return { android: scheme, ios: scheme };
+        }
+        // Channel handle e.g. /@handle or /channel/ID
+        const scheme = `vnd.youtube://www.youtube.com${url.pathname}`;
+        return { android: scheme, ios: scheme };
+    },
+
+    x: (url) => {
+        const handle = url.pathname.replace(/^\/|\/$/g, "").split("/")[0];
+        if (!handle) return { android: null, ios: null };
+        const scheme = `twitter://user?screen_name=${handle}`;
+        return { android: scheme, ios: scheme };
+    },
+
+    twitch: (url) => {
+        const channel = url.pathname.replace(/^\/|\/$/g, "").split("/")[0];
+        if (!channel) return { android: null, ios: null };
+        const scheme = `twitch://stream/${channel}`;
+        return { android: scheme, ios: scheme };
+    },
+
+    linkedin: (url) => {
+        const path = url.pathname; // e.g. /in/username
+        return {
+            // Android uses an intent URI
+            android: `intent://linkedin.com${path}#Intent;package=com.linkedin.android;scheme=https;end`,
+            ios: `linkedin://${path}`,
+        };
+    },
+
+    facebook: (url) => {
+        return {
+            android: `fb://facewebmodal/f?href=${encodeURIComponent(url.href)}`,
+            ios: `fb://profile`,
+        };
+    },
+};
+
+// ─── Exported Utilities ───────────────────────────────────────────────────────
+
+export function normalizeUrl(url: string): string {
     let u = url.trim();
-    if (!/^https?:/i.test(u)) {
-        u = "https://" + u;
-    }
+    if (!/^https?:/i.test(u)) u = "https://" + u;
     return u.replace(/\/$/, "");
 }
 
@@ -43,26 +113,45 @@ export function detectPlatform(url: string): Platform {
     const normalized = normalizeUrl(url);
 
     for (const [platform, regex] of Object.entries(PLATFORM_PATTERNS)) {
-        if (regex.test(normalized)) {
-            return platform as Platform;
-        }
+        // Skip the catch-all until the end
+        if (platform === "website") continue;
+        if (regex.test(normalized)) return platform as Platform;
     }
 
     return "website";
 }
 
-export function validatePlatformUrl(
-    platform: Platform,
-    url: string
-): boolean {
+export function validatePlatformUrl(platform: Platform, url: string): boolean {
     const normalized = normalizeUrl(url);
 
-    if (
-        normalized.includes("/messaging/") ||
-        normalized.includes("/feed/")
-    ) {
-        return false;
-    }
+    const blocklist = PLATFORM_BLOCKLIST[platform];
+    if (blocklist?.test(normalized)) return false;
 
     return PLATFORM_PATTERNS[platform].test(normalized);
+}
+
+/**
+ * Detects Android / iOS from a User-Agent string.
+ */
+export function getMobileOS(
+    userAgent: string
+): "android" | "ios" | "unknown" {
+    if (/android/i.test(userAgent)) return "android";
+    if (/iphone|ipad|ipod/i.test(userAgent)) return "ios";
+    return "unknown";
+}
+
+/**
+ * Returns native app URI schemes for a platform + web URL.
+ * Returns `{ android: null, ios: null }` for unsupported platforms.
+ */
+export function getDeepLink(platform: string, webUrl: string): DeepLinkResult {
+    const builder = DEEP_LINK_BUILDERS[platform as Platform];
+    if (!builder) return { android: null, ios: null };
+
+    try {
+        return builder(new URL(webUrl));
+    } catch {
+        return { android: null, ios: null };
+    }
 }


### PR DESCRIPTION
Resolves #237 

### Summary
Adds a Smart Intent Routing engine that detects the user's device type on link click and routes mobile users through native app URI schemes instead of plain `https://` redirects. This eliminates the "forced web login" problem on mobile, improving conversion rates and UX for creators sharing their links.

---

### Problem
When a mobile user clicked a LinkID redirect (e.g. `linkid.qzz.io/vishnu/instagram`), they were sent to `instagram.com` in their mobile browser, forcing them to log in again — causing high bounce rates and a poor experience.

---

### Changes

#### `lib/platforms.ts`
- Added `getMobileOS(userAgent)` — detects `android` | `ios` | `unknown` from the `User-Agent` header
- Added `getDeepLink(platform, webUrl)` — maps a platform + web URL to native app URI schemes (e.g. `instagram://user?username=vishnu`, `vnd.youtube://VIDEO_ID`, `twitter://user?screen_name=handle`)
- Added `DEEP_LINK_BUILDERS` — per-platform builders for Instagram, YouTube, X/Twitter, Twitch, LinkedIn, Facebook
- Added `PLATFORM_BLOCKLIST` — per-platform regex rules to block non-profile URLs (replaces fragile `includes()` string checks)
- Tightened all `PLATFORM_PATTERNS` regexes to use platform-specific character classes instead of `[^/]+`
- Fixed `detectPlatform` to skip the `website` catch-all during iteration

#### `app/[username]/[platform]/page.tsx`
- Reads the `User-Agent` header from the incoming request
- On mobile: serves a lightweight HTML page that fires the app URI scheme and falls back to the web URL after 2 seconds if the app isn't installed
- On desktop: plain `redirect()` as before — no behaviour change
- Added `visibilitychange` listener to cancel the fallback timer when the app successfully opens
- Added an explicit "Open in browser instead" fallback link for users
- Added `<meta httpEquiv="refresh">` as a JS-disabled safety net

---

### Deep Link Scheme Reference

| Platform | Scheme |
|---|---|
| Instagram | `instagram://user?username=USERNAME` |
| YouTube (video) | `vnd.youtube://VIDEO_ID` |
| YouTube (channel) | `vnd.youtube://www.youtube.com/@handle` |
| X / Twitter | `twitter://user?screen_name=HANDLE` |
| Twitch | `twitch://stream/CHANNEL` |
| LinkedIn | `linkedin:///in/USERNAME` (iOS) / intent URI (Android) |
| Facebook | `fb://facewebmodal/f?href=...` |

---

### How to Test

**DevTools (instant):**
1. Open Chrome DevTools → Network conditions → set a mobile User-Agent
2. Navigate to `localhost:3000/yourUsername/instagram`
3. You should see the "Opening instagram app..." intermediate page

**curl:**
```bash
# Should return HTML containing instagram:// scheme
curl -s -A "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36" \
  http://localhost:3000/yourUsername/instagram | grep "instagram://"

# Should return a Location redirect header (desktop unchanged)
curl -I -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" \
  http://localhost:3000/yourUsername/instagram
```

**Real device:** Use `npx ngrok http 3000` and open the tunnel URL on your phone.

---

### Notes
- No database schema changes
- No breaking changes to existing redirect behaviour on desktop
- Platforms without reliable deep link support (GitHub, LeetCode, Discord, etc.) silently fall back to web redirect
- `getMobileOS` and `getDeepLink` are pure functions and easy to unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent mobile app routing that detects user device and automatically opens native platform apps when available. Supports Android and iOS with graceful fallback to web version if the app isn't installed. Covers Instagram, YouTube, Twitter, LinkedIn, Facebook, Twitch, GitHub, and Discord.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->