### PR TITLE
Amt/link fix

### DIFF
--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -3,101 +3,102 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 
-import { validatePlatformUrl, detectPlatform } from "@/lib/platforms";
+import {
+  validatePlatformUrl,
+  detectPlatform,
+  isKnownPlatform,
+} from "@/lib/platforms";
 import { validateUrlBackend } from "@/lib/urlValidation";
 
 export async function PUT(
-    req: Request,
-    context: { params: Promise<{ id: string }> }
+  req: Request,
+  context: { params: Promise<{ id: string }> },
 ) {
-    const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-    if (!session?.user?.email) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const body = await req.json();
+  const url = body?.url;
+  const isPublic = body?.isPublic;
+
+  const link = await prisma.link.findUnique({
+    where: { id },
+    include: { user: true },
+  });
+
+  if (!link || link.user.email !== session.user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const data: { url?: string; isPublic?: boolean } = {};
+
+  if (typeof url === "string") {
+    const validation = validateUrlBackend(url);
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
-    const { id } = await context.params;
-    const body = await req.json();
-    const url = body?.url;
-    const isPublic = body?.isPublic;
+    const finalUrl = validation.normalizedUrl;
 
-    const link = await prisma.link.findUnique({
-        where: { id },
-        include: { user: true },
-    });
+    const platformForValidation = isKnownPlatform(link.platform)
+      ? link.platform
+      : detectPlatform(finalUrl);
 
-    if (!link || link.user.email !== session.user.email) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    if (!validatePlatformUrl(platformForValidation, finalUrl)) {
+      return NextResponse.json(
+        { error: "Please enter a valid public link" },
+        { status: 400 },
+      );
     }
 
-    const data: { url?: string; isPublic?: boolean } = {};
+    data.url = finalUrl;
+  }
 
-    if (typeof url === "string") {
-        const validation = validateUrlBackend(url);
-        if (!validation.valid) {
-            return NextResponse.json(
-                { error: validation.error },
-                { status: 400 }
-            );
-        }
+  if (typeof isPublic === "boolean") {
+    data.isPublic = isPublic;
+  }
 
-        const finalUrl = validation.normalizedUrl;
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
 
-        // Derive platform from the final URL for validation so custom user-defined
-        // platform slugs (e.g. when platform was stored as a custom label) don't
-        // cause a runtime exception in `validatePlatformUrl`.
-        const platformForValidation = detectPlatform(finalUrl);
+  await prisma.link.update({
+    where: { id },
+    data,
+  });
 
-        if (!validatePlatformUrl(platformForValidation, finalUrl)) {
-            return NextResponse.json(
-                { error: "Please enter a valid public link" },
-                { status: 400 }
-            );
-        }
-
-        data.url = finalUrl;
-    }
-
-    if (typeof isPublic === "boolean") {
-        data.isPublic = isPublic;
-    }
-
-    if (Object.keys(data).length === 0) {
-        return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
-    }
-
-    await prisma.link.update({
-        where: { id },
-        data,
-    });
-
-    return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true });
 }
 
 export async function DELETE(
-    req: Request,
-    context: { params: Promise<{ id: string }> }
+  req: Request,
+  context: { params: Promise<{ id: string }> },
 ) {
-    const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-    if (!session?.user?.email) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    const { id } = await context.params;
+  const { id } = await context.params;
 
-    const link = await prisma.link.findUnique({
-        where: { id },
-        include: { user: true },
-    });
+  const link = await prisma.link.findUnique({
+    where: { id },
+    include: { user: true },
+  });
 
-    if (!link || link.user.email !== session.user.email) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+  if (!link || link.user.email !== session.user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
-    await prisma.link.delete({
-        where: { id },
-    });
+  await prisma.link.delete({
+    where: { id },
+  });
 
-    return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true });
 }
+

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -17,6 +17,7 @@ import toast from "react-hot-toast";
 import { useState } from "react";
 import { PLATFORM_ICONS } from "@/lib/platformIcons";
 import { validateUrl } from "@/lib/urlValidation";
+import { validatePlatformUrl, isKnownPlatform, normalizeUrl } from "@/lib/platforms";
 import type { Link as ProfileLink } from "@/app/[username]/types/type";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -55,6 +56,10 @@ export function LinkItem({
         const validation = validateUrl(url);
         if (!validation.valid) {
             return toast.error(validation.error);
+        }
+
+        if (isKnownPlatform(link.platform) && !validatePlatformUrl(link.platform, normalizeUrl(url))) {
+            return toast.error(`Please enter a valid ${link.label || link.platform} link`);
         }
 
         await onUpdate(link.id, url);

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,13 @@ services:
     container_name: linkid-postgres
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: linkid
     ports:
       - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init:/docker-entrypoint-initdb.d
+
+volumes:
+  postgres_data:

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -1,1 +1,273 @@
-CREATE DATABASE linkid;
+-- CreateEnum
+CREATE TYPE "JobStatus" AS ENUM ('PENDING', 'SCHEDULED', 'PROCESSING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+    "password" TEXT,
+    "username" TEXT,
+    "bio" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserAlias" (
+    "id" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserAlias_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Link" (
+    "id" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "clicks" INTEGER NOT NULL DEFAULT 0,
+    "isPublic" BOOLEAN NOT NULL DEFAULT true,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Link_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ClickEvent" (
+    "id" TEXT NOT NULL,
+    "linkId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "visitorKey" TEXT,
+    "userAgent" TEXT,
+    "referrer" TEXT,
+    "country" TEXT,
+    "deviceType" TEXT,
+    "isBot" BOOLEAN NOT NULL DEFAULT false,
+    "isUniqueVisitor" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ClickEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DailyLinkAnalytics" (
+    "id" TEXT NOT NULL,
+    "linkId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "totalClicks" INTEGER NOT NULL DEFAULT 0,
+    "uniqueClicks" INTEGER NOT NULL DEFAULT 0,
+    "botClicks" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DailyLinkAnalytics_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AccountMergeRequest" (
+    "id" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "consumedByUserId" TEXT,
+
+    CONSTRAINT "AccountMergeRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AccountMergeEvent" (
+    "id" TEXT NOT NULL,
+    "sourceUserId" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "sourceEmail" TEXT NOT NULL,
+    "targetEmail" TEXT NOT NULL,
+    "sourceUsername" TEXT,
+    "targetUsername" TEXT,
+    "mergedLinks" INTEGER NOT NULL DEFAULT 0,
+    "mergedAccounts" INTEGER NOT NULL DEFAULT 0,
+    "transferredSessions" INTEGER NOT NULL DEFAULT 0,
+    "conflictsJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AccountMergeEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VerificationToken" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "UsernameHistory" (
+    "id" TEXT NOT NULL,
+    "previousUsername" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UsernameHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProfileDraft" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT,
+    "username" TEXT,
+    "bio" TEXT,
+    "image" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfileDraft_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProfileVersion" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT,
+    "username" TEXT,
+    "bio" TEXT,
+    "image" TEXT,
+    "changeType" TEXT NOT NULL,
+    "diffJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProfileVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProfilePreviewToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ProfilePreviewToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" "JobStatus" NOT NULL DEFAULT 'PENDING',
+    "scheduleAt" TIMESTAMP(3),
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "lastError" TEXT,
+    "runAfter" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "deleteOtp" (
+    "userId" TEXT NOT NULL,
+    "otp" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "sendCount" INTEGER NOT NULL DEFAULT 0,
+    "windowStart" TIMESTAMP(3),
+
+    CONSTRAINT "deleteOtp_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateTable
+CREATE TABLE "invalidatedSession" (
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invalidatedSession_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+CREATE UNIQUE INDEX "UserAlias_username_key" ON "UserAlias"("username");
+CREATE INDEX "UserAlias_userId_idx" ON "UserAlias"("userId");
+CREATE UNIQUE INDEX "Link_userId_platform_key" ON "Link"("userId", "platform");
+CREATE INDEX "ClickEvent_linkId_createdAt_idx" ON "ClickEvent"("linkId", "createdAt");
+CREATE INDEX "ClickEvent_userId_createdAt_idx" ON "ClickEvent"("userId", "createdAt");
+CREATE INDEX "ClickEvent_linkId_visitorKey_createdAt_idx" ON "ClickEvent"("linkId", "visitorKey", "createdAt");
+CREATE INDEX "ClickEvent_createdAt_idx" ON "ClickEvent"("createdAt");
+CREATE UNIQUE INDEX "DailyLinkAnalytics_linkId_date_key" ON "DailyLinkAnalytics"("linkId", "date");
+CREATE INDEX "DailyLinkAnalytics_userId_date_idx" ON "DailyLinkAnalytics"("userId", "date");
+CREATE INDEX "DailyLinkAnalytics_date_idx" ON "DailyLinkAnalytics"("date");
+CREATE UNIQUE INDEX "AccountMergeRequest_codeHash_key" ON "AccountMergeRequest"("codeHash");
+CREATE INDEX "AccountMergeRequest_targetUserId_createdAt_idx" ON "AccountMergeRequest"("targetUserId", "createdAt");
+CREATE INDEX "AccountMergeRequest_expiresAt_idx" ON "AccountMergeRequest"("expiresAt");
+CREATE INDEX "AccountMergeEvent_sourceUserId_idx" ON "AccountMergeEvent"("sourceUserId");
+CREATE INDEX "AccountMergeEvent_targetUserId_createdAt_idx" ON "AccountMergeEvent"("targetUserId", "createdAt");
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+CREATE UNIQUE INDEX "UsernameHistory_previousUsername_key" ON "UsernameHistory"("previousUsername");
+CREATE UNIQUE INDEX "ProfileDraft_userId_key" ON "ProfileDraft"("userId");
+CREATE INDEX "ProfileDraft_userId_idx" ON "ProfileDraft"("userId");
+CREATE INDEX "ProfileVersion_userId_createdAt_idx" ON "ProfileVersion"("userId", "createdAt");
+CREATE UNIQUE INDEX "ProfilePreviewToken_tokenHash_key" ON "ProfilePreviewToken"("tokenHash");
+CREATE INDEX "ProfilePreviewToken_userId_expiresAt_idx" ON "ProfilePreviewToken"("userId", "expiresAt");
+CREATE INDEX "Job_status_runAfter_idx" ON "Job"("status", "runAfter");
+CREATE INDEX "Job_scheduleAt_idx" ON "Job"("scheduleAt");
+CREATE INDEX "deleteOtp_windowStart_idx" ON "deleteOtp"("windowStart");
+
+-- AddForeignKey
+ALTER TABLE "UserAlias" ADD CONSTRAINT "UserAlias_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Link" ADD CONSTRAINT "Link_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ClickEvent" ADD CONSTRAINT "ClickEvent_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "DailyLinkAnalytics" ADD CONSTRAINT "DailyLinkAnalytics_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AccountMergeRequest" ADD CONSTRAINT "AccountMergeRequest_targetUserId_fkey" FOREIGN KEY ("targetUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "UsernameHistory" ADD CONSTRAINT "UsernameHistory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProfileDraft" ADD CONSTRAINT "ProfileDraft_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProfileVersion" ADD CONSTRAINT "ProfileVersion_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProfilePreviewToken" ADD CONSTRAINT "ProfilePreviewToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -51,6 +51,10 @@ export function detectPlatform(url: string): Platform {
     return "website";
 }
 
+export function isKnownPlatform(p: string): p is Platform {
+    return p in PLATFORM_PATTERNS;
+}
+
 export function validatePlatformUrl(
     platform: Platform,
     url: string


### PR DESCRIPTION
## Summary

   - On edit, the PUT handler now validates the new URL against the **stored** platform slug (using `isKnownPlatform`) instead of re-detecting the platform from the incoming URL — preventing cross-platform
   URL substitution
   - Added `isKnownPlatform` helper to `lib/platforms.ts` to safely narrow a stored string to the `Platform` union
   - Added client-side validation in `LinkItem.tsx` so the error is surfaced instantly without a round-trip, matching the platform check in the API

   Closes #225

   ## Test plan

   - [ ] Create a GitHub link → edit it → paste a YouTube URL → confirm save is rejected with a clear error message
   - [ ] Edit a GitHub link → paste a valid GitHub profile URL → confirm save succeeds
   - [ ] Edit a link whose platform is a custom/unknown value → confirm it still saves without false-positive rejection
   - [ ] Verify the `isPublic` toggle still works independently of URL validation
