### PR TITLE
fix(links): validate URLs against stored platform slug on update

### DIFF
--- a/app/api/links/[id]/route.test.ts
+++ b/app/api/links/[id]/route.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { mock, test, before } from "node:test";
+
+// ── Mutable state shared across mock closures ─────────────────────────────────
+let mockSession: unknown = null;
+let mockLink: unknown = null;
+let capturedUpdateArgs: unknown = null;
+
+// ── Register mocks synchronously BEFORE any module import ─────────────────────
+
+mock.module("next-auth", {
+    namedExports: {
+        getServerSession: () => Promise.resolve(mockSession),
+    },
+});
+
+mock.module("@/lib/auth", {
+    namedExports: { authOptions: {} },
+});
+
+mock.module("@/lib/prisma", {
+    defaultExport: {
+        link: {
+            findUnique: () => Promise.resolve(mockLink),
+            update: (args: unknown) => {
+                capturedUpdateArgs = args;
+                return Promise.resolve({});
+            },
+        },
+    },
+    namedExports: {
+        prisma: {
+            link: {
+                findUnique: () => Promise.resolve(mockLink),
+                update: (args: unknown) => {
+                    capturedUpdateArgs = args;
+                    return Promise.resolve({});
+                },
+            },
+        },
+    },
+});
+
+// Dynamic import in before() so it's after mock registration but before tests.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let PUT: (...args: any[]) => Promise<Response>;
+
+before(async () => {
+    const route = await import("@/app/api/links/[id]/route");
+    PUT = route.PUT;
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function putRequest(body: unknown): Request {
+    return new Request("http://localhost/api/links/test-id", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function ctx(id = "test-id") {
+    return { params: Promise.resolve({ id }) };
+}
+
+function ownerLink(platform = "github") {
+    return { id: "test-id", platform, user: { email: "owner@example.com" } };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("PUT 401 — no session", async () => {
+    mockSession = null;
+    const res = await PUT(putRequest({ url: "https://github.com/user" }), ctx());
+    assert.equal(res.status, 401);
+    assert.deepEqual(await res.json(), { error: "Unauthorized" });
+});
+
+test("PUT 403 — link belongs to a different user", async () => {
+    mockSession = { user: { email: "attacker@example.com" } };
+    mockLink = ownerLink();
+    const res = await PUT(putRequest({ url: "https://github.com/user" }), ctx());
+    assert.equal(res.status, 403);
+});
+
+test("PUT 403 — link not found", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = null;
+    const res = await PUT(putRequest({ url: "https://github.com/user" }), ctx());
+    assert.equal(res.status, 403);
+});
+
+test("PUT 400 — URL fails basic validation (malformed)", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink();
+    // "not-valid" → https://not-valid → single part hostname, no TLD
+    const res = await PUT(putRequest({ url: "not-valid" }), ctx());
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.ok(body.error, "expected an error message");
+});
+
+test("PUT 400 — URL does not match stored platform (different-platform URL)", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink("github");
+    // Valid LinkedIn URL for a GitHub link → platform mismatch
+    const res = await PUT(putRequest({ url: "https://linkedin.com/in/john-doe" }), ctx());
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { error: "Please enter a valid public link" });
+});
+
+test("PUT 400 — nothing to update (empty body)", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink();
+    const res = await PUT(putRequest({}), ctx());
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { error: "Nothing to update" });
+});
+
+test("PUT 200 — valid URL matching stored platform updates the link", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink("github");
+    capturedUpdateArgs = null;
+    const res = await PUT(putRequest({ url: "https://github.com/newuser" }), ctx());
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { success: true });
+    assert.ok(capturedUpdateArgs, "prisma.link.update should have been called");
+});
+
+test("PUT 200 — isPublic boolean update without URL", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink();
+    capturedUpdateArgs = null;
+    const res = await PUT(putRequest({ isPublic: false }), ctx());
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { success: true });
+    assert.ok(capturedUpdateArgs, "prisma.link.update should have been called");
+});
+
+test("PUT 400 — non-boolean isPublic with no URL is treated as nothing to update", async () => {
+    mockSession = { user: { email: "owner@example.com" } };
+    mockLink = ownerLink();
+    const res = await PUT(putRequest({ isPublic: "yes" }), ctx());
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { error: "Nothing to update" });
+});

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -3,101 +3,102 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 
-import { validatePlatformUrl, detectPlatform } from "@/lib/platforms";
+import {
+  validatePlatformUrl,
+  detectPlatform,
+  isKnownPlatform,
+} from "@/lib/platforms";
 import { validateUrlBackend } from "@/lib/urlValidation";
 
 export async function PUT(
-    req: Request,
-    context: { params: Promise<{ id: string }> }
+  req: Request,
+  context: { params: Promise<{ id: string }> },
 ) {
-    const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-    if (!session?.user?.email) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const body = await req.json();
+  const url = body?.url;
+  const isPublic = body?.isPublic;
+
+  const link = await prisma.link.findUnique({
+    where: { id },
+    include: { user: true },
+  });
+
+  if (!link || link.user.email !== session.user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const data: { url?: string; isPublic?: boolean } = {};
+
+  if (typeof url === "string") {
+    const validation = validateUrlBackend(url);
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
-    const { id } = await context.params;
-    const body = await req.json();
-    const url = body?.url;
-    const isPublic = body?.isPublic;
+    const finalUrl = validation.normalizedUrl;
 
-    const link = await prisma.link.findUnique({
-        where: { id },
-        include: { user: true },
-    });
+    const platformForValidation = isKnownPlatform(link.platform)
+      ? link.platform
+      : detectPlatform(finalUrl);
 
-    if (!link || link.user.email !== session.user.email) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    if (!validatePlatformUrl(platformForValidation, finalUrl)) {
+      return NextResponse.json(
+        { error: "Please enter a valid public link" },
+        { status: 400 },
+      );
     }
 
-    const data: { url?: string; isPublic?: boolean } = {};
+    data.url = finalUrl;
+  }
 
-    if (typeof url === "string") {
-        const validation = validateUrlBackend(url);
-        if (!validation.valid) {
-            return NextResponse.json(
-                { error: validation.error },
-                { status: 400 }
-            );
-        }
+  if (typeof isPublic === "boolean") {
+    data.isPublic = isPublic;
+  }
 
-        const finalUrl = validation.normalizedUrl;
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
 
-        // Derive platform from the final URL for validation so custom user-defined
-        // platform slugs (e.g. when platform was stored as a custom label) don't
-        // cause a runtime exception in `validatePlatformUrl`.
-        const platformForValidation = detectPlatform(finalUrl);
+  await prisma.link.update({
+    where: { id },
+    data,
+  });
 
-        if (!validatePlatformUrl(platformForValidation, finalUrl)) {
-            return NextResponse.json(
-                { error: "Please enter a valid public link" },
-                { status: 400 }
-            );
-        }
-
-        data.url = finalUrl;
-    }
-
-    if (typeof isPublic === "boolean") {
-        data.isPublic = isPublic;
-    }
-
-    if (Object.keys(data).length === 0) {
-        return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
-    }
-
-    await prisma.link.update({
-        where: { id },
-        data,
-    });
-
-    return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true });
 }
 
 export async function DELETE(
-    req: Request,
-    context: { params: Promise<{ id: string }> }
+  req: Request,
+  context: { params: Promise<{ id: string }> },
 ) {
-    const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-    if (!session?.user?.email) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    const { id } = await context.params;
+  const { id } = await context.params;
 
-    const link = await prisma.link.findUnique({
-        where: { id },
-        include: { user: true },
-    });
+  const link = await prisma.link.findUnique({
+    where: { id },
+    include: { user: true },
+  });
 
-    if (!link || link.user.email !== session.user.email) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+  if (!link || link.user.email !== session.user.email) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
-    await prisma.link.delete({
-        where: { id },
-    });
+  await prisma.link.delete({
+    where: { id },
+  });
 
-    return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true });
 }
+

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -58,7 +58,7 @@ export function LinkItem({
             return toast.error(validation.error);
         }
 
-        if (isKnownPlatform(link.platform) && !validatePlatformUrl(link.platform, normalizeUrl(url))) {
+        if (isKnownPlatform(link.platform) && !validatePlatformUrl(link.platform, url)) {
             return toast.error(`Please enter a valid ${link.label || link.platform} link`);
         }
 

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -17,6 +17,7 @@ import toast from "react-hot-toast";
 import { useState } from "react";
 import { PLATFORM_ICONS } from "@/lib/platformIcons";
 import { validateUrl } from "@/lib/urlValidation";
+import { validatePlatformUrl, isKnownPlatform, normalizeUrl } from "@/lib/platforms";
 import type { Link as ProfileLink } from "@/app/[username]/types/type";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -55,6 +56,10 @@ export function LinkItem({
         const validation = validateUrl(url);
         if (!validation.valid) {
             return toast.error(validation.error);
+        }
+
+        if (isKnownPlatform(link.platform) && !validatePlatformUrl(link.platform, normalizeUrl(url))) {
+            return toast.error(`Please enter a valid ${link.label || link.platform} link`);
         }
 
         await onUpdate(link.id, url);

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -17,7 +17,7 @@ import toast from "react-hot-toast";
 import { useState } from "react";
 import { PLATFORM_ICONS } from "@/lib/platformIcons";
 import { validateUrl } from "@/lib/urlValidation";
-import { validatePlatformUrl, isKnownPlatform, normalizeUrl } from "@/lib/platforms";
+import { validatePlatformUrl, isKnownPlatform } from "@/lib/platforms";
 import type { Link as ProfileLink } from "@/app/[username]/types/type";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -59,7 +59,7 @@ export function LinkItem({
         }
 
         if (isKnownPlatform(link.platform) && !validatePlatformUrl(link.platform, url)) {
-            return toast.error(`Please enter a valid ${link.label || link.platform} link`);
+            return toast.error(`Enter valid link for chosen platform`);
         }
 
         await onUpdate(link.id, url);

--- a/lib/platforms.test.ts
+++ b/lib/platforms.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validatePlatformUrl, isKnownPlatform } from "@/lib/platforms";
+
+// --- isKnownPlatform ---
+
+test("isKnownPlatform returns true for every declared platform", () => {
+    const known = [
+        "github", "linkedin", "leetcode", "youtube", "x",
+        "facebook", "instagram", "discord", "twitch",
+        "hashnode", "devto", "medium", "dribbble", "website",
+    ];
+    for (const p of known) {
+        assert.equal(isKnownPlatform(p), true, `expected true for "${p}"`);
+    }
+});
+
+test("isKnownPlatform returns false for unknown and custom labels", () => {
+    for (const p of ["twitter", "tiktok", "custom", "GITHUB", "", "mysite"]) {
+        assert.equal(isKnownPlatform(p), false, `expected false for "${p}"`);
+    }
+});
+
+test("isKnownPlatform is not fooled by prototype keys", () => {
+    assert.equal(isKnownPlatform("__proto__"), false);
+    assert.equal(isKnownPlatform("constructor"), false);
+    assert.equal(isKnownPlatform("toString"), false);
+});
+
+// --- validatePlatformUrl ---
+
+test("validatePlatformUrl accepts valid URLs for each platform", () => {
+    assert.equal(validatePlatformUrl("github", "https://github.com/octocat"), true);
+    assert.equal(validatePlatformUrl("github", "http://github.com/octocat"), true);
+    assert.equal(validatePlatformUrl("github", "https://www.github.com/octocat"), true);
+    assert.equal(validatePlatformUrl("github", "github.com/octocat"), true);
+    assert.equal(validatePlatformUrl("linkedin", "https://linkedin.com/in/john-doe"), true);
+    assert.equal(validatePlatformUrl("linkedin", "https://www.linkedin.com/company/acme"), true);
+    assert.equal(validatePlatformUrl("leetcode", "https://leetcode.com/jsmith"), true);
+    assert.equal(validatePlatformUrl("leetcode", "https://www.leetcode.com/jsmith"), true);
+    assert.equal(validatePlatformUrl("youtube", "https://youtube.com/@channel"), true);
+    assert.equal(validatePlatformUrl("youtube", "https://www.youtube.com/c/channelname"), true);
+    assert.equal(validatePlatformUrl("x", "https://x.com/username"), true);
+    assert.equal(validatePlatformUrl("x", "https://www.x.com/username"), true);
+    assert.equal(validatePlatformUrl("facebook", "https://facebook.com/username"), true);
+    assert.equal(validatePlatformUrl("facebook", "https://www.facebook.com/username"), true);
+    assert.equal(validatePlatformUrl("instagram", "https://instagram.com/username"), true);
+    assert.equal(validatePlatformUrl("discord", "https://discord.com/users/123456789"), true);
+    assert.equal(validatePlatformUrl("twitch", "https://twitch.tv/streamer"), true);
+    assert.equal(validatePlatformUrl("hashnode", "https://hashnode.com/@user"), true);
+    assert.equal(validatePlatformUrl("hashnode", "https://user.hashnode.dev"), true);
+    assert.equal(validatePlatformUrl("devto", "https://dev.to/username"), true);
+    assert.equal(validatePlatformUrl("medium", "https://medium.com/@author"), true);
+    assert.equal(validatePlatformUrl("medium", "https://medium.com/publication"), true);
+    assert.equal(validatePlatformUrl("dribbble", "https://dribbble.com/designer"), true);
+    assert.equal(validatePlatformUrl("website", "https://my-portfolio.com"), true);
+    assert.equal(validatePlatformUrl("website", "https://blog.example.com/posts"), true);
+});
+
+test("validatePlatformUrl rejects URLs that don't match the platform", () => {
+    assert.equal(validatePlatformUrl("github", "https://gitlab.com/octocat"), false);
+    assert.equal(validatePlatformUrl("github", "https://github.io/octocat"), false);
+    assert.equal(validatePlatformUrl("x", "https://twitter.com/username"), false);
+    assert.equal(validatePlatformUrl("youtube", "https://vimeo.com/channel"), false);
+    assert.equal(validatePlatformUrl("instagram", "https://threads.net/user"), false);
+    assert.equal(validatePlatformUrl("twitch", "https://youtube.com/@streamer"), false);
+});
+
+test("validatePlatformUrl rejects cross-platform URL swaps", () => {
+    assert.equal(validatePlatformUrl("github", "https://linkedin.com/in/octocat"), false);
+    assert.equal(validatePlatformUrl("linkedin", "https://github.com/john"), false);
+    assert.equal(validatePlatformUrl("linkedin", "https://glassdoor.com/john"), false);
+    assert.equal(validatePlatformUrl("leetcode", "https://hackerrank.com/jsmith"), false);
+    assert.equal(validatePlatformUrl("leetcode", "https://github.com/jsmith"), false);
+    assert.equal(validatePlatformUrl("youtube", "https://twitch.tv/channel"), false);
+    assert.equal(validatePlatformUrl("x", "https://facebook.com/username"), false);
+    assert.equal(validatePlatformUrl("facebook", "https://instagram.com/username"), false);
+    assert.equal(validatePlatformUrl("facebook", "https://x.com/username"), false);
+    assert.equal(validatePlatformUrl("instagram", "https://facebook.com/user"), false);
+    assert.equal(validatePlatformUrl("discord", "https://slack.com/users/123"), false);
+    assert.equal(validatePlatformUrl("discord", "https://discord.gg/invite"), false);
+    assert.equal(validatePlatformUrl("twitch", "https://kick.com/streamer"), false);
+    assert.equal(validatePlatformUrl("hashnode", "https://medium.com/@user"), false);
+    assert.equal(validatePlatformUrl("devto", "https://medium.com/@user"), false);
+    assert.equal(validatePlatformUrl("devto", "https://hashnode.com/@user"), false);
+    assert.equal(validatePlatformUrl("medium", "https://dev.to/username"), false);
+    assert.equal(validatePlatformUrl("medium", "https://substack.com/@author"), false);
+    assert.equal(validatePlatformUrl("dribbble", "https://behance.net/designer"), false);
+    assert.equal(validatePlatformUrl("dribbble", "https://figma.com/@designer"), false);
+});
+
+test("validatePlatformUrl rejects LinkedIn /messaging/ and /feed/ paths", () => {
+    assert.equal(validatePlatformUrl("linkedin", "https://linkedin.com/messaging/thread/123"), false);
+    assert.equal(validatePlatformUrl("linkedin", "https://www.linkedin.com/feed/"), false);
+});
+
+test("validatePlatformUrl rejects /messaging/ and /feed/ paths on any platform", () => {
+    assert.equal(validatePlatformUrl("website", "https://example.com/messaging/inbox"), false);
+    assert.equal(validatePlatformUrl("website", "https://example.com/feed/update"), false);
+});

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -51,6 +51,10 @@ export function detectPlatform(url: string): Platform {
     return "website";
 }
 
+export function isKnownPlatform(p: string): p is Platform {
+    return p in PLATFORM_PATTERNS;
+}
+
 export function validatePlatformUrl(
     platform: Platform,
     url: string

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -52,7 +52,7 @@ export function detectPlatform(url: string): Platform {
 }
 
 export function isKnownPlatform(p: string): p is Platform {
-    return p in PLATFORM_PATTERNS;
+  return Object.prototype.hasOwnProperty.call(PLATFORM_PATTERNS, p);
 }
 
 export function validatePlatformUrl(


### PR DESCRIPTION
Closes #225    
 Previously, the PUT /api/links/[id] route always re-detected the
    platform from the submitted URL, which caused validation to fail or
    use the wrong rules when a link's stored platform differed from what
    detectPlatform() would infer (e.g. custom labels or edge-case URLs).

    - Add isKnownPlatform() type guard to lib/platforms.ts
    - In the PUT handler, use the link's stored platform for validation if it is a known platform, falling back to detectPlatform() only for custom/unknown slugs
    - Add matching frontend validation in LinkItem.tsx so invalid URLs are rejected client-side before the API call is made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Platform validation when updating links now prefers the stored platform when recognized, falling back to URL-based detection otherwise.
  * Editing a link enforces platform-specific URL validation on save and shows immediate error feedback for invalid URLs.

* **Tests**
  * Added server and unit tests covering update flows, authorization checks, and platform/URL validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->