### PR TITLE
feat(auth): add sign out confirmation dialog(#213)

### DIFF
--- a/app/components/DashboardNavbar.tsx
+++ b/app/components/DashboardNavbar.tsx
@@ -9,6 +9,14 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import { ThemeToggle } from "./ThemeToggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -34,6 +42,7 @@ export function DashboardNavbar() {
     const { data: session } = useSession();
     const user = session?.user;
     const [scrolled, setScrolled] = useState(false);
+    const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
 
     useEffect(() => {
         const onScroll = () => setScrolled(window.scrollY > 8);
@@ -51,6 +60,7 @@ export function DashboardNavbar() {
         : "U";
 
     return (
+        <>
         <header
             className={`sticky top-0 z-50 w-full border-b transition-shadow duration-300 ${scrolled
                     ? "border-violet-200/70 bg-white/85 shadow-md shadow-violet-950/[0.07] dark:border-white/10 dark:bg-zinc-950/85 dark:shadow-black/30"
@@ -166,7 +176,7 @@ export function DashboardNavbar() {
 
                             <DropdownMenuItem
                                 className="mx-1 mb-1 flex cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-red-600 focus:bg-red-50 focus:text-red-700 dark:text-red-400 dark:focus:bg-red-950/40 dark:focus:text-red-300"
-                                onClick={() => signOut({ callbackUrl: "/login" })}
+                                onClick={() => setSignOutDialogOpen(true)}
                             >
                                 <LogOut className="h-4 w-4" />
                                 Sign out
@@ -176,5 +186,42 @@ export function DashboardNavbar() {
                 </div>
             </div>
         </header>
+        <Dialog
+    open={signOutDialogOpen}
+    onOpenChange={setSignOutDialogOpen}
+>
+    <DialogContent>
+        <DialogHeader>
+            <DialogTitle>
+                Confirm Sign Out
+            </DialogTitle>
+
+            <DialogDescription>
+                Are you sure you want to sign out of your account?
+            </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+            <Button
+                variant="outline"
+                onClick={() => setSignOutDialogOpen(false)}
+            >
+                Cancel
+            </Button>
+
+            <Button
+                variant="destructive"
+                onClick={() =>
+                    signOut({
+                        callbackUrl: "/login",
+                    })
+                }
+            >
+                Sign out
+            </Button>
+        </DialogFooter>
+    </DialogContent>
+</Dialog>
+</>
     );
 }

--- a/app/components/DashboardNavbar.tsx
+++ b/app/components/DashboardNavbar.tsx
@@ -44,8 +44,10 @@ export function DashboardNavbar() {
     const user = session?.user;
     const [scrolled, setScrolled] = useState(false);
     const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
+    const [dropdownOpen, setDropdownOpen] = useState(false);
     async function handleSignOut() {
         setSignOutDialogOpen(false);
+        setDropdownOpen(false);
         try {
             await signOut({
                 callbackUrl: "/login",
@@ -113,7 +115,10 @@ export function DashboardNavbar() {
                     <ThemeToggle />
 
                     {/* User dropdown */}
-                    <DropdownMenu>
+                    <DropdownMenu
+                     open={dropdownOpen} 
+                     onOpenChange={setDropdownOpen}
+                     >
                         <DropdownMenuTrigger asChild>
                             <Button
                                 variant="ghost"
@@ -189,7 +194,7 @@ export function DashboardNavbar() {
 
                             <DropdownMenuItem
                                 className="mx-1 mb-1 flex cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-red-600 focus:bg-red-50 focus:text-red-700 dark:text-red-400 dark:focus:bg-red-950/40 dark:focus:text-red-300"
-                                onClick={() => setSignOutDialogOpen(true)}
+                                onClick={() => {setDropdownOpen(false);setSignOutDialogOpen(true); }}
                             >
                                 <LogOut className="h-4 w-4" />
                                 Sign out

--- a/app/components/DashboardNavbar.tsx
+++ b/app/components/DashboardNavbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signOut, useSession } from "next-auth/react";
+import toast from "react-hot-toast";
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -43,6 +44,18 @@ export function DashboardNavbar() {
     const user = session?.user;
     const [scrolled, setScrolled] = useState(false);
     const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
+    async function handleSignOut() {
+        setSignOutDialogOpen(false);
+        try {
+            await signOut({
+                callbackUrl: "/login",
+            });
+        } catch {
+            toast.error(
+                "Failed to sign out. Please try again."
+            );
+        }
+    }
 
     useEffect(() => {
         const onScroll = () => setScrolled(window.scrollY > 8);
@@ -211,11 +224,7 @@ export function DashboardNavbar() {
 
             <Button
                 variant="destructive"
-                onClick={() =>
-                    signOut({
-                        callbackUrl: "/login",
-                    })
-                }
+                onClick={handleSignOut}
             >
                 Sign out
             </Button>


### PR DESCRIPTION
## Description

Adds a confirmation dialog before signing out from the dashboard navbar dropdown to prevent accidental logout and improve overall sign-out user experience.

The dialog provides:

* Cancel → keeps the user logged in
* Sign out → logs the user out and redirects to `/login`

Implemented using existing `shadcn/ui` Dialog components while following the project's TypeScript and Tailwind conventions.

## Related Issue

Closes #213 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation
* [ ] Refactor

## How to Test

1. Login to the application
2. Open the dashboard navbar dropdown
3. Click on "Sign out"
4. Verify that a confirmation dialog appears
5. Click "Cancel" and verify the user remains logged in
6. Click "Sign out" and verify logout redirects to `/login`

## Screenshots (if UI change)

<img width="781" height="246" alt="Screenshot 2026-05-27 142059" src="https://github.com/user-attachments/assets/17e386ac-d36f-4837-bb6e-2c172398bb42" />

## Checklist

* [x] Code follows project conventions
* [x] Self-reviewed the changes
* [x] No console.log left behind
* [x] No new TypeScript errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign out now requires confirmation from the dashboard navbar: a dialog appears allowing users to cancel or confirm.
  * Confirming signs the user out and redirects to the login page.
  * Sign-out failures show an error notification so users are informed.
  * The user menu and sign-out flow have improved, more predictable behavior when opening/closing the dialog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->