### PR TITLE
fix(analytics): validate proxy chain before trusting X-Forwarded-For, add click rate limit (issue #257)

### DIFF
--- a/app/api/links/click/route.ts
+++ b/app/api/links/click/route.ts
@@ -1,8 +1,23 @@
 import prisma from "@/lib/prisma";
 import { NextResponse } from "next/server";
 import { trackLinkClick } from "@/lib/analytics";
+import { getForwardedIp } from "@/lib/analyticsUtils";
+import { checkRateLimit } from "@/lib/rateLimit";
+
+// 30 requests per minute per IP on the click endpoint.
+const CLICK_RATE_LIMIT = 30;
+const CLICK_RATE_WINDOW_MS = 60 * 1000;
 
 export async function POST(req: Request) {
+    const ip = getForwardedIp(req.headers) ?? "unknown";
+    const allowed = checkRateLimit(`click:${ip}`, CLICK_RATE_LIMIT, CLICK_RATE_WINDOW_MS);
+    if (!allowed) {
+        return NextResponse.json(
+            { error: "Too many requests. Please slow down." },
+            { status: 429 },
+        );
+    }
+
     const { username, platform } = await req.json();
 
     if (!username || !platform) {

--- a/app/api/links/click/route.ts
+++ b/app/api/links/click/route.ts
@@ -14,7 +14,10 @@ export async function POST(req: Request) {
     if (!allowed) {
         return NextResponse.json(
             { error: "Too many requests. Please slow down." },
-            { status: 429 },
+            {
+                status: 429,
+                headers: { "Retry-After": String(Math.ceil(CLICK_RATE_WINDOW_MS / 1000)) },
+            },
         );
     }
 

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { detectDeviceType, isLikelyBot } from "@/lib/analyticsUtils";
+import { detectDeviceType, getForwardedIp, isLikelyBot, isPrivateIp } from "@/lib/analyticsUtils";
 
 test("isLikelyBot identifies common crawler user agents", () => {
     assert.equal(isLikelyBot("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"), true);
@@ -38,4 +38,56 @@ test("detectDeviceType classifies mobile, tablet and desktop", () => {
         ),
         "desktop"
     );
+});
+
+// isPrivateIp
+test("isPrivateIp returns true for RFC-1918 and loopback ranges", () => {
+    assert.equal(isPrivateIp("10.0.0.1"), true);
+    assert.equal(isPrivateIp("10.255.255.255"), true);
+    assert.equal(isPrivateIp("172.16.0.1"), true);
+    assert.equal(isPrivateIp("172.31.255.255"), true);
+    assert.equal(isPrivateIp("192.168.1.1"), true);
+    assert.equal(isPrivateIp("127.0.0.1"), true);
+});
+
+test("isPrivateIp returns false for public IPs", () => {
+    assert.equal(isPrivateIp("1.2.3.4"), false);
+    assert.equal(isPrivateIp("8.8.8.8"), false);
+    assert.equal(isPrivateIp("172.15.0.1"), false);   // just outside 172.16/12
+    assert.equal(isPrivateIp("172.32.0.1"), false);   // just outside 172.16/12
+    assert.equal(isPrivateIp("203.0.113.1"), false);  // TEST-NET-3, public
+});
+
+test("isPrivateIp rejects malformed values", () => {
+    assert.equal(isPrivateIp("not-an-ip"), false);
+    assert.equal(isPrivateIp(""), false);
+    assert.equal(isPrivateIp("10.0.0"), false);
+});
+
+// getForwardedIp
+test("getForwardedIp returns x-real-ip directly when upstream is public", () => {
+    const h = new Headers({
+        "x-real-ip": "203.0.113.5",
+        "x-forwarded-for": "10.0.0.1, 203.0.113.5",
+    });
+    // Upstream (x-real-ip) is public, so x-forwarded-for must be ignored.
+    assert.equal(getForwardedIp(h), "203.0.113.5");
+});
+
+test("getForwardedIp trusts x-forwarded-for first hop when upstream is private", () => {
+    const h = new Headers({
+        "x-real-ip": "10.0.0.2",         // private proxy
+        "x-forwarded-for": "203.0.113.9, 10.0.0.2",
+    });
+    assert.equal(getForwardedIp(h), "203.0.113.9");
+});
+
+test("getForwardedIp returns null when no IP headers present", () => {
+    assert.equal(getForwardedIp(new Headers()), null);
+});
+
+test("getForwardedIp ignores spoofed x-forwarded-for when x-real-ip is absent", () => {
+    const h = new Headers({ "x-forwarded-for": "1.2.3.4" });
+    // No x-real-ip means we cannot verify the proxy chain.
+    assert.equal(getForwardedIp(h), null);
 });

--- a/lib/analyticsUtils.ts
+++ b/lib/analyticsUtils.ts
@@ -2,15 +2,58 @@ import { createHash } from "node:crypto";
 
 const BOT_USER_AGENT_RE = /(bot|spider|crawler|bingpreview|slurp|duckduckbot|baiduspider|yandex|facebookexternalhit|twitterbot|whatsapp|telegrambot|discordbot|linkedinbot|headless|lighthouse)/i;
 
+/**
+ * Returns true when the given IPv4 address falls inside one of the RFC-1918
+ * private ranges (10/8, 172.16/12, 192.168/16) or the loopback range (127/8).
+ *
+ * Only IPv4 is checked here because X-Forwarded-For values from typical
+ * reverse-proxy deployments (nginx, Vercel edge, ALB) are IPv4.
+ */
+export function isPrivateIp(ip: string): boolean {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
+        return false;
+    }
+    const [a, b] = parts;
+    return (
+        a === 10 ||
+        a === 127 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168)
+    );
+}
+
+/**
+ * Derives the real client IP from request headers in a way that resists
+ * spoofing via a client-supplied X-Forwarded-For header.
+ *
+ * Trust hierarchy (highest to lowest):
+ *   1. x-real-ip  -- set by trusted infrastructure (Vercel edge, nginx real_ip).
+ *      Never forwarded from the client; use this as-is when present.
+ *   2. x-forwarded-for (first hop) -- trusted ONLY when x-real-ip indicates
+ *      the immediate upstream is a private/loopback address, meaning the
+ *      request arrived through a known internal reverse proxy.
+ *      If the upstream IP is public, the header may have been injected by the
+ *      client and is discarded.
+ *
+ * This prevents an attacker from rotating X-Forwarded-For values to generate
+ * unique visitorKeys and bypass the 24-hour deduplication window.
+ */
 export function getForwardedIp(headers: Headers): string | null {
-    const forwardedFor = headers.get("x-forwarded-for");
-    if (forwardedFor) {
-        const first = forwardedFor.split(",")[0]?.trim();
-        if (first) return first;
+    const realIp = headers.get("x-real-ip")?.trim() || null;
+
+    // If the direct upstream is a private proxy, the x-forwarded-for chain was
+    // set by trusted infrastructure and the first entry is the real client IP.
+    if (realIp && isPrivateIp(realIp)) {
+        const forwardedFor = headers.get("x-forwarded-for");
+        if (forwardedFor) {
+            const first = forwardedFor.split(",")[0]?.trim();
+            if (first) return first;
+        }
     }
 
-    const realIp = headers.get("x-real-ip")?.trim();
-    return realIp || null;
+    // Fall back to x-real-ip (set by Vercel/nginx, not spoofable by clients).
+    return realIp;
 }
 
 export function isLikelyBot(userAgent: string | null | undefined): boolean {

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,48 @@
+/**
+ * Lightweight in-memory sliding-window rate limiter for Next.js API routes.
+ *
+ * Each call to `checkRateLimit` records a timestamp for the given key and
+ * returns whether the caller has exceeded the allowed request count within
+ * the rolling window.
+ *
+ * Suitable for single-instance deployments (local dev, single-container).
+ * For multi-instance production, swap the internal store for a shared Redis
+ * backend (e.g. Upstash) while keeping the same public interface.
+ */
+
+type WindowEntry = {
+    timestamps: number[];
+};
+
+const store = new Map<string, WindowEntry>();
+
+/**
+ * Check whether `key` has exceeded `limit` requests in the last
+ * `windowMs` milliseconds.
+ *
+ * @returns `true` when the request is allowed, `false` when the limit is hit.
+ */
+export function checkRateLimit(
+    key: string,
+    limit: number,
+    windowMs: number,
+): boolean {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+
+    let entry = store.get(key);
+    if (!entry) {
+        entry = { timestamps: [] };
+        store.set(key, entry);
+    }
+
+    // Evict timestamps outside the current window.
+    entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+    if (entry.timestamps.length >= limit) {
+        return false;
+    }
+
+    entry.timestamps.push(now);
+    return true;
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -16,6 +16,22 @@ type WindowEntry = {
 
 const store = new Map<string, WindowEntry>();
 
+// Periodic full-store sweep so keys added by one-off or rotating IPs do not
+// accumulate indefinitely. A sweep removes every key whose window has fully
+// expired, bounding Map growth to the number of distinct keys seen within one
+// rolling window rather than the lifetime of the process.
+let requestsSinceCleanup = 0;
+const CLEANUP_INTERVAL = 500; // sweep after every N requests
+
+function sweepExpiredKeys(windowMs: number): void {
+    const cutoff = Date.now() - windowMs;
+    for (const [key, entry] of store.entries()) {
+        if (entry.timestamps.every((t) => t <= cutoff)) {
+            store.delete(key);
+        }
+    }
+}
+
 /**
  * Check whether `key` has exceeded `limit` requests in the last
  * `windowMs` milliseconds.
@@ -29,6 +45,14 @@ export function checkRateLimit(
 ): boolean {
     const now = Date.now();
     const cutoff = now - windowMs;
+
+    // Periodic sweep to prevent unbounded Map growth from rotating or
+    // one-off keys (e.g. rotating attacker IPs on an unauthenticated endpoint).
+    requestsSinceCleanup++;
+    if (requestsSinceCleanup >= CLEANUP_INTERVAL) {
+        requestsSinceCleanup = 0;
+        sweepExpiredKeys(windowMs);
+    }
 
     let entry = store.get(key);
     if (!entry) {


### PR DESCRIPTION
## Summary

Fixes #257.

`getForwardedIp` in `lib/analyticsUtils.ts` unconditionally trusted the first value from `X-Forwarded-For`. Any unauthenticated client could rotate that header on every request to generate a unique `visitorKey`, bypassing the 24-hour deduplication window and inflating `uniqueClicks` without limit.

## Changes

### `lib/analyticsUtils.ts`

Added `isPrivateIp(ip: string): boolean` that checks RFC-1918 ranges (10/8, 172.16/12, 192.168/16) and loopback (127/8).

Rewrote `getForwardedIp` with a safe trust hierarchy:
1. **`x-real-ip` first** -- set by trusted infrastructure (Vercel edge, nginx `real_ip`), never forwardable by clients.
2. **`x-forwarded-for` (first hop)** -- trusted only when `x-real-ip` identifies the upstream as a private proxy. If the upstream is public, the header was client-supplied and is discarded.

```typescript
// Before -- client controls the IP used for deduplication
const forwardedFor = headers.get("x-forwarded-for");
if (forwardedFor) return forwardedFor.split(",")[0]?.trim();

// After -- X-Forwarded-For only trusted through verified private proxies
if (realIp && isPrivateIp(realIp)) { /* trust x-forwarded-for */ }
return realIp;  // fall back to infrastructure-set header
```

### `lib/rateLimit.ts` (new)

Lightweight sliding-window in-memory rate limiter. Designed with a simple interface so the backing store can be swapped for Redis/Upstash in a multi-instance deployment without changing call sites.

### `app/api/links/click/route.ts`

Applies **30 req/min per IP** before any database access. Returns `429 Too Many Requests` when exceeded.

### `lib/analytics.test.ts`

Added 7 new test cases for `isPrivateIp` and the updated `getForwardedIp`. All **10 tests pass**.

## Test results

```
pass 10 / fail 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click tracking now enforces per-client rate limits (30 clicks per minute); excess requests receive HTTP 429 with a Retry-After header.

* **Improvements**
  * Improved client IP detection behind proxies to better distinguish private vs public upstreams, reducing spoofed/incorrect attribution.

* **Tests**
  * Expanded test coverage for IP classification and forwarded-IP handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->