### PR TITLE
fix(avatar): validate image magic bytes before Cloudinary upload (issue #259)

### DIFF
--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { v2 as cloudinary } from "cloudinary";
+import { hasSupportedImageMagicBytes } from "@/lib/imageValidation";
 
 cloudinary.config({
     cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
@@ -22,7 +23,7 @@ export async function POST(req: Request) {
         return Response.json({ error: "No file provided" }, { status: 400 });
     }
 
-    // Validate file type
+    // Validate declared MIME type (first-pass, client-supplied but cheap to check).
     const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
     if (!allowedTypes.includes(file.type)) {
         return Response.json({ error: "Only JPG, PNG and WebP allowed" }, { status: 400 });
@@ -36,6 +37,19 @@ export async function POST(req: Request) {
     // Convert file to buffer
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
+
+    // Validate actual file content via magic bytes.
+    // file.type is the MIME type declared by the client in the multipart
+    // Content-Type field, which is entirely attacker-controlled.
+    // This check reads the first 12 bytes of the buffer to verify that the
+    // payload is genuinely a JPEG, PNG, or WebP image regardless of what
+    // the client declared.
+    if (!hasSupportedImageMagicBytes(buffer)) {
+        return Response.json(
+            { error: "File content does not match a supported image format (JPG, PNG or WebP)" },
+            { status: 400 },
+        );
+    }
 
     // Upload to Cloudinary
     const result = await new Promise<{ secure_url: string }>((resolve, reject) => {

--- a/lib/imageValidation.test.ts
+++ b/lib/imageValidation.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasSupportedImageMagicBytes } from "@/lib/imageValidation";
+
+// Helper to build a Buffer from a hex string ("FF D8 FF" etc.)
+function fromHex(hex: string): Buffer {
+    return Buffer.from(hex.replace(/\s/g, ""), "hex");
+}
+
+// Pad a buffer to at least 12 bytes so the length guard does not interfere.
+function pad(buf: Buffer): Buffer {
+    if (buf.length >= 12) return buf;
+    return Buffer.concat([buf, Buffer.alloc(12 - buf.length)]);
+}
+
+test("hasSupportedImageMagicBytes accepts a valid JPEG header", () => {
+    const jpeg = pad(fromHex("FF D8 FF E0 00 10 4A 46 49 46 00 01"));
+    assert.equal(hasSupportedImageMagicBytes(jpeg), true);
+});
+
+test("hasSupportedImageMagicBytes accepts a valid PNG header", () => {
+    const png = pad(fromHex("89 50 4E 47 0D 0A 1A 0A 00 00 00 0D"));
+    assert.equal(hasSupportedImageMagicBytes(png), true);
+});
+
+test("hasSupportedImageMagicBytes accepts a valid WebP header", () => {
+    // RIFF....WEBP where .... is 4 arbitrary size bytes
+    const webp = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, // RIFF
+        0x24, 0x00, 0x00, 0x00, // file size (arbitrary)
+        0x57, 0x45, 0x42, 0x50, // WEBP
+    ]);
+    assert.equal(hasSupportedImageMagicBytes(webp), true);
+});
+
+test("hasSupportedImageMagicBytes rejects a plain text file", () => {
+    const txt = Buffer.from("Hello, world! This is not an image.");
+    assert.equal(hasSupportedImageMagicBytes(txt), false);
+});
+
+test("hasSupportedImageMagicBytes rejects a PDF file header", () => {
+    const pdf = pad(fromHex("25 50 44 46 2D")); // %PDF-
+    assert.equal(hasSupportedImageMagicBytes(pdf), false);
+});
+
+test("hasSupportedImageMagicBytes rejects a GIF file header", () => {
+    const gif = pad(Buffer.from("GIF89a"));
+    assert.equal(hasSupportedImageMagicBytes(gif), false);
+});
+
+test("hasSupportedImageMagicBytes rejects a buffer shorter than 12 bytes", () => {
+    const short = Buffer.from([0xff, 0xd8, 0xff]); // valid JPEG prefix but too short
+    assert.equal(hasSupportedImageMagicBytes(short), false);
+});
+
+test("hasSupportedImageMagicBytes rejects an empty buffer", () => {
+    assert.equal(hasSupportedImageMagicBytes(Buffer.alloc(0)), false);
+});
+
+test("hasSupportedImageMagicBytes rejects a RIFF container that is not WebP", () => {
+    // RIFF....AVI  -- a valid RIFF container but not a WebP image
+    const avi = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, // RIFF
+        0x00, 0x00, 0x00, 0x00, // size
+        0x41, 0x56, 0x49, 0x20, // AVI (not WEBP)
+    ]);
+    assert.equal(hasSupportedImageMagicBytes(avi), false);
+});

--- a/lib/imageValidation.ts
+++ b/lib/imageValidation.ts
@@ -1,0 +1,54 @@
+/**
+ * Magic-byte validation for uploaded image files.
+ *
+ * File-type detection based on the first bytes of the binary content is the
+ * only reliable server-side check because the MIME type declared in the
+ * multipart form-data Content-Type field is entirely client-controlled.
+ *
+ * Supported formats and their signatures:
+ *
+ *   JPEG  FF D8 FF          (first 3 bytes)
+ *   PNG   89 50 4E 47       (first 4 bytes, i.e. \x89PNG)
+ *   WebP  52 49 46 46 .. .. .. .. 57 45 42 50
+ *         bytes 0-3 = "RIFF", bytes 8-11 = "WEBP"
+ *
+ * References:
+ *   https://www.garykessler.net/library/file_sigs.html
+ *   https://developers.google.com/speed/webp/docs/riff_container
+ */
+
+/**
+ * Returns true when `buf` begins with the magic-byte signature of a JPEG,
+ * PNG, or WebP image.  The buffer must contain at least 12 bytes; anything
+ * shorter is rejected.
+ */
+export function hasSupportedImageMagicBytes(buf: Buffer): boolean {
+    if (buf.length < 12) return false;
+
+    // JPEG: starts with FF D8 FF
+    if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return true;
+
+    // PNG: starts with 89 50 4E 47 (i.e. \x89PNG)
+    if (
+        buf[0] === 0x89 &&
+        buf[1] === 0x50 &&
+        buf[2] === 0x4e &&
+        buf[3] === 0x47
+    )
+        return true;
+
+    // WebP: bytes 0-3 are "RIFF" and bytes 8-11 are "WEBP"
+    const isRiff =
+        buf[0] === 0x52 && // R
+        buf[1] === 0x49 && // I
+        buf[2] === 0x46 && // F
+        buf[3] === 0x46;   // F
+    const isWebp =
+        buf[8] === 0x57 && // W
+        buf[9] === 0x45 && // E
+        buf[10] === 0x42 && // B
+        buf[11] === 0x50;  // P
+    if (isRiff && isWebp) return true;
+
+    return false;
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "node scripts/postinstall-prisma-generate.mjs",
     "migrate:deploy:safe": "node scripts/safe-prisma-migrate-deploy.mjs",
     "lint": "eslint",
-    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts lib/analytics.test.ts lib/accountMergeUtils.test.ts"
+    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts lib/analytics.test.ts lib/accountMergeUtils.test.ts lib/imageValidation.test.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",


### PR DESCRIPTION
## Summary

Fixes #259.

`POST /api/profile/avatar` validated uploaded files by checking `file.type`, which is the MIME type declared by the client in the multipart `Content-Type` field. This is entirely attacker-controlled: any file bypasses the check by declaring `Content-Type: image/jpeg`.

## Changes

### `lib/imageValidation.ts` (new)

`hasSupportedImageMagicBytes(buf: Buffer): boolean` reads the first 12 bytes to verify the actual file signature:

| Format | Signature |
|--------|-----------|
| JPEG | `FF D8 FF` (first 3 bytes) |
| PNG | `89 50 4E 47` (first 4 bytes) |
| WebP | bytes 0-3 = `RIFF`, bytes 8-11 = `WEBP` |

Buffers shorter than 12 bytes are rejected outright.

### `app/api/profile/avatar/route.ts`

After converting the file to a `Buffer`, the magic-byte check runs before `cloudinary.uploader.upload_stream`. The existing declared-MIME check is kept as a cheap first pass.

```typescript
// After buffer conversion, before Cloudinary upload:
if (!hasSupportedImageMagicBytes(buffer)) {
    return Response.json(
        { error: "File content does not match a supported image format (JPG, PNG or WebP)" },
        { status: 400 },
    );
}
```

### `lib/imageValidation.test.ts` (new)

9 test cases: valid JPEG, PNG, and WebP headers; plain text, PDF, GIF rejections; too-short buffer; empty buffer; non-WebP RIFF container.

### `package.json`

Added `lib/imageValidation.test.ts` to the `test` npm script.

## Test results

```
pass 9 / fail 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar uploads now include enhanced file validation that inspects uploaded content before processing.

* **Tests**
  * Added comprehensive test coverage for image validation across supported formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->