### PR TITLE
fix(profile): merge draft profile fields with live values

### DIFF
--- a/lib/profileWorkflow.ts
+++ b/lib/profileWorkflow.ts
@@ -65,13 +65,20 @@ export async function getEditableProfileState(
   const draft = await prisma.profileDraft.findUnique({
     where: { userId },
   });
-
   if (draft) {
+    // Merge draft with live user values so missing draft fields fall back
+    // to the current live profile (avoids returning nulls when only
+    // a subset of fields are being edited in the draft).
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { name: true, username: true, bio: true, image: true },
+    });
+
     return {
-      name: draft.name,
-      username: draft.username,
-      bio: draft.bio,
-      image: draft.image,
+      name: draft.name ?? user?.name ?? null,
+      username: draft.username ?? user?.username ?? null,
+      bio: draft.bio ?? user?.bio ?? null,
+      image: draft.image ?? user?.image ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in `getEditableProfileState()` where existing profile drafts could unintentionally hide live profile values.

Previously, if a draft existed, the function returned the draft record directly. Because draft records may contain `null` for fields that were not edited, valid values from the live profile could be replaced with `null` in the editable state.

This change merges draft values with the live profile so unedited draft fields inherit current live values.

## Problem

Given:

Live profile:

```json
{
  "name": "John Doe",
  "username": "johndoe"
}
```

Draft profile:

```json
{
  "name": "John Smith",
  "username": null
}
```

Previous result:

```json
{
  "name": "John Smith",
  "username": null
}
```

Expected result:

```json
{
  "name": "John Smith",
  "username": "johndoe"
}
```

## Solution

When a draft exists:

1. Fetch the current live user profile.
2. Return a merged editable state.
3. Use draft values when present.
4. Fall back to live profile values when draft fields are `null` or unset.

Pattern used:

```ts
draft.field ?? user.field ?? null
```

## Files Changed

- `profileWorkflow.ts`
  - Updated `getEditableProfileState()` to merge draft and live profile values.

## Testing

### Manual Verification

1. Created a user with populated profile fields.
2. Created a partial draft updating only a subset of fields.
3. Retrieved editable profile state.
4. Confirmed unedited fields now fall back to live profile values.

### Automated Tests

```bash
npm test
```

All existing tests passed successfully.

## Impact

- Prevents editable profile data from losing existing values.
- Improves consistency between live profile state and draft editing experience.
- Reduces risk of UI issues caused by unexpected null fields.

Issue #278 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile draft editing to properly display current user data as fallback values for fields not yet completed in the draft, preventing null values from appearing in edit forms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->