### PR TITLE
Fix Bio field nesting, reorder username feedback, and improve accessibility in EditProfileCard

### DIFF
--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -134,18 +134,20 @@ export default function EditProfileCard({
                             ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
                         </div>
                     )}
-                    {available === true && (
-                        <p className="flex items-center gap-1 text-sm text-green-600">
-                            <Check className="h-4 w-4" /> Username available
-                        </p>
-                    )}
+                    
+                    <div role="status" aria-live="polite" aria-atomic="true">
+                        {available === true && (
+                            <p className="flex items-center gap-1 text-sm text-green-600">
+                                <Check className="h-4 w-4" /> Username available
+                            </p>
+                        )}
 
-                    {available === false && (
-                        <p className="flex items-center gap-1 text-sm text-red-600">
-                            <X className="h-4 w-4" /> Username already taken
-                        </p>
-                    )}
-
+                        {available === false && (
+                            <p className="flex items-center gap-1 text-sm text-red-600">
+                                <X className="h-4 w-4" /> Username already taken
+                            </p>
+                        )}
+                    </div>
                 </div>
                 
                 <div className="space-y-1">

--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -135,20 +135,6 @@ export default function EditProfileCard({
                         </div>
                     )}
 
-                    <div className="space-y-1">
-                        <Label>Bio</Label>
-                        <textarea
-                            className="w-full rounded-md border p-2 text-sm"
-                            maxLength={160}
-                            value={bio}
-                            onChange={(e) => setBio(e.target.value)}
-                            placeholder="Tell something about yourself..."
-                        />
-                        <p className="text-xs text-muted-foreground text-right">
-                            {bio.length}/160
-                        </p>
-                    </div>
-
 
                     {available === true && (
                         <p className="flex items-center gap-1 text-sm text-green-600">
@@ -161,6 +147,20 @@ export default function EditProfileCard({
                             <X className="h-4 w-4" /> Username already taken
                         </p>
                     )}
+                </div>
+                
+                <div className="space-y-1">
+                    <Label>Bio</Label>
+                    <textarea
+                        className="w-full rounded-md border p-2 text-sm"
+                        maxLength={160}
+                        value={bio}
+                        onChange={(e) => setBio(e.target.value)}
+                        placeholder="Tell something about yourself..."
+                    />
+                    <p className="text-xs text-muted-foreground text-right">
+                        {bio.length}/160
+                    </p>
                 </div>
 
                 <Button

--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -129,6 +129,11 @@ export default function EditProfileCard({
                         />
                     </div>
 
+                    {username !== initialUsername && (
+                        <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+                            ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
+                        </div>
+                    )}
                     {available === true && (
                         <p className="flex items-center gap-1 text-sm text-green-600">
                             <Check className="h-4 w-4" /> Username available
@@ -141,11 +146,6 @@ export default function EditProfileCard({
                         </p>
                     )}
 
-                    {username !== initialUsername && (
-                        <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
-                            ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
-                        </div>
-                    )}
                 </div>
                 
                 <div className="space-y-1">

--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -129,13 +129,6 @@ export default function EditProfileCard({
                         />
                     </div>
 
-                    {username !== initialUsername && (
-                        <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
-                            ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
-                        </div>
-                    )}
-
-
                     {available === true && (
                         <p className="flex items-center gap-1 text-sm text-green-600">
                             <Check className="h-4 w-4" /> Username available
@@ -146,6 +139,12 @@ export default function EditProfileCard({
                         <p className="flex items-center gap-1 text-sm text-red-600">
                             <X className="h-4 w-4" /> Username already taken
                         </p>
+                    )}
+
+                    {username !== initialUsername && (
+                        <div className="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+                            ⚠️ <strong>Heads up:</strong> Changing your username may affect existing shared links. Old links will automatically redirect to your new username.
+                        </div>
                     )}
                 </div>
                 

--- a/app/profile/EditProfileCard.tsx
+++ b/app/profile/EditProfileCard.tsx
@@ -136,13 +136,19 @@ export default function EditProfileCard({
                     )}
                     
                     <div role="status" aria-live="polite" aria-atomic="true">
+                        {checking && (
+                            <p className="text-sm text-muted-foreground">
+                                Checking availability...
+                            </p>
+                        )}
+
                         {available === true && (
                             <p className="flex items-center gap-1 text-sm text-green-600">
                                 <Check className="h-4 w-4" /> Username available
                             </p>
                         )}
 
-                        {available === false && (
+                        {!checking && available === false && (
                             <p className="flex items-center gap-1 text-sm text-red-600">
                                 <X className="h-4 w-4" /> Username already taken
                             </p>


### PR DESCRIPTION
fixes #280 

### 📋 Summary
This PR fixes a structural bug where the Bio field was incorrectly nested inside the Username block in EditProfileCard. It also reorders the username change warning and availability indicators for better UX, and adds ARIA live region support for screen readers.

### 🔍 Problem
The Bio field was nested inside the Username <div> instead of being a sibling element. This caused:

- Username availability indicators rendering after the Bio field
- Broken DOM tab order for keyboard users
- Screen readers announcing Bio before username validation feedback
- Yellow warning box appearing after availability indicators instead of before


### ✅ Changes
1. Extract Bio field out of Username block
Bio is now a sibling of the Username block, not a child.
2. Reorder warning box above availability indicators
The yellow "Heads up" warning now appears before the ✓ / ✗ availability feedback, giving a more logical reading flow.
3. Add aria-live region for availability feedback
Wrapped availability indicators in a role="status" div so screen readers announce changes dynamically and immediately after username input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of username availability feedback in the profile editor by ensuring messages are properly announced to screen reader users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnukothakapu/linkid/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->