### PR TITLE
fix(links): use 1-based positions when reordering links

### DIFF
--- a/app/api/links/reorder/route.ts
+++ b/app/api/links/reorder/route.ts
@@ -63,8 +63,9 @@ export async function POST(req: Request) {
     const currentMap = new Map(current.map((c) => [c.id, c.position]));
 
     type UpdatePayload = { id: string; newOrder: number };
+    // Use 1-based positions to remain consistent with creation/backfill logic
     const updates: UpdatePayload[] = ids
-      .map((id, idx) => ({ id, newOrder: idx }))
+      .map((id, idx) => ({ id, newOrder: idx + 1 }))
       .filter(({ id, newOrder }) => currentMap.get(id) !== newOrder);
 
     if (updates.length === 0) return NextResponse.json({ ok: true, changed: 0 });


### PR DESCRIPTION
# Fix: Standardize link reorder positions to 1-based indexing

## Summary

This PR fixes an inconsistency in link position handling by updating the reorder endpoint to use 1-based indexing.

Previously, reordered links were saved using 0-based positions while link creation and position backfill logic used 1-based positions.

This caused inconsistent ordering data and potential off-by-one issues throughout the application.

## Root Cause

Different parts of the system used different indexing conventions:

### Creation

```ts
position = existingLinks.length + 1;
```

### Backfill

```ts
position = index + 1;
```

### Reorder (Before)

```ts
newOrder = idx;
```

As a result, reordered records could contain position values starting at `0`, while all other workflows expected positions to start at `1`.

## Changes Made

Updated reorder logic from:

```ts
newOrder: idx
```

to:

```ts
newOrder: idx + 1
```

This aligns reorder behavior with:

* Link creation
* Position backfill scripts
* Existing ordering assumptions throughout the application

## Example

### Before Reorder

```text
1, 2, 3, 4
```

### After Reorder (Old Behavior)

```text
0, 1, 2, 3
```

### After Reorder (New Behavior)

```text
1, 2, 3, 4
```

with the reordered sequence preserved.

## Testing

Verified:

* Newly created links still receive 1-based positions.
* Reordered links are stored using 1-based positions.
* Backfill logic remains consistent.
* Ordering is preserved after multiple reorder operations.

## Benefits

* Eliminates off-by-one position inconsistencies.
* Keeps all position management workflows aligned.
* Prevents ordering mismatches between frontend and backend.
* Simplifies future maintenance by enforcing a single indexing convention.

Fixes #300 
