### PR TITLE
fix(auth): use authOptions with getServerSession

### DIFF
--- a/app/api/profile/versions/route.ts
+++ b/app/api/profile/versions/route.ts
@@ -1,11 +1,12 @@
 import { getProfileVersions } from "@/lib/profileWorkflow";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   try {
-    const session = await getServerSession();
+    const session = await getServerSession(authOptions);
     if (!session?.user?.email) {
       return NextResponse.json(
         { error: "Unauthorized" },


### PR DESCRIPTION
## Screenshot (when helpful)

N/A – Backend authentication consistency fix. No UI changes.

---

## What this PR does

This PR fixes inconsistent session handling in the link API route by passing the application's configured `authOptions` to `getServerSession`.

### Problem

The route was calling:

```ts
const session = await getServerSession();
```

without supplying the shared NextAuth configuration.

As a result, the route could resolve sessions differently from other authenticated routes that correctly use `authOptions`, potentially causing authentication inconsistencies.

### Solution

* Added the missing `authOptions` import.
* Updated the session lookup to use:

```ts
const session = await getServerSession(authOptions);
```

This ensures the route uses the same authentication configuration as the rest of the application.

### Benefits

* Consistent session handling across API routes
* Correct usage of NextAuth configuration
* Reduced risk of authentication and authorization bugs
* Easier maintenance by using a single source of truth for auth settings

---

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Code refactor
* [ ] Documentation update

---

## Related issue

Fixes #307 
---

## More screenshots (optional)

N/A

---

## Checklist

* [x] I have added screenshots or a recording when they help explain this PR, or noted **N/A** with a one-line reason.
* [x] I have filled in the related issue number when there is one.
* [x] I have tested my changes.
* [x] I have done a self-review of the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated profile versions API endpoint to use centralized authentication configuration for improved consistency in security handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->