### PR TITLE
[FEAT] Add aria-label attributes to platform icon links on public profile page for screen reader accessibility

### DIFF
--- a/app/[username]/ProfileLinkItem.tsx
+++ b/app/[username]/ProfileLinkItem.tsx
@@ -16,11 +16,14 @@ export function ProfileLinkItem({ link, username }: ProfileLinks) {
     const Icon =
         PLATFORM_ICONS[link.platform] ?? Globe;
 
+    const ariaLabel = `Visit ${link.label || link.platform}`;
+
     return (
         <a
             href={`/${username}/${link.platform}`}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={ariaLabel}
             className="group flex items-center justify-between rounded-lg border bg-background px-4 py-3 transition hover:bg-muted"
         >
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Description

Adds `aria-label` attributes to all platform icon links on the public profile page (`/[username]`). Screen readers now announce the platform name instead of just "link".

## Changes

- **`app/[username]/ProfileLinkItem.tsx`** — Added `aria-label="Visit ${link.label || link.platform}"` to the anchor tag wrapping each platform icon

## Acceptance Criteria

- [x] Every platform icon link has a unique `aria-label`
- [x] GitHub, LinkedIn, LeetCode, YouTube, X, Instagram, Facebook, Discord, Twitch icons all get appropriate labels
- [x] Custom website links dynamically generate labels from the user's custom link label
- [x] No duplicate, empty, or generic `aria-label` values
- [x] Page remains visually identical — zero visual diff
- [x] Screen reader announces the platform name, not just "link"
- [x] All existing functionality unchanged

Closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced profile links with improved accessible naming for assistive technologies, providing clearer context when navigating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->