### PR TITLE
fix(platforms): tighten LinkedIn and Facebook URL validation to block internal and broken URLs

### DIFF
--- a/lib/platform.test.ts
+++ b/lib/platform.test.ts
@@ -56,4 +56,70 @@ describe("Platform Utilities - Regression Tests", () => {
       assert.strictEqual(link.ios, "https://www.youtube.com/shorts/hW9_8k8Gjks");
     });
   });
+
+  // 4. Facebook blocked paths regression tests
+  describe("validatePlatformUrl() - Facebook Blocked Paths", () => {
+    it("should reject facebook.com/messages", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/messages"), false);
+    });
+
+    it("should reject facebook.com/feed/ (trailing slash)", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/feed/"), false);
+    });
+
+    it("should reject facebook.com/gaming", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/gaming"), false);
+    });
+
+    it("should reject facebook.com/watch", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/watch"), false);
+    });
+
+    it("should reject facebook.com/marketplace", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/marketplace"), false);
+    });
+
+    it("should reject facebook.com/profile.php without id parameter", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/profile.php"), false);
+    });
+
+    it("should allow facebook.com/profile.php?id=123456", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/profile.php?id=123456"), true);
+    });
+
+    it("should allow valid facebook.com public username", () => {
+      assert.strictEqual(validatePlatformUrl("facebook", "https://www.facebook.com/johndoe"), true);
+    });
+  });
+
+  // 5. LinkedIn blocked paths regression tests
+  describe("validatePlatformUrl() - LinkedIn Blocked Paths", () => {
+    it("should reject linkedin.com/feed/", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/feed/"), false);
+    });
+
+    it("should reject linkedin.com/mynetwork", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/mynetwork"), false);
+    });
+
+    it("should reject linkedin.com/jobs", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/jobs"), false);
+    });
+
+    it("should reject linkedin.com/learning", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/learning"), false);
+    });
+
+    it("should allow linkedin.com/in/username", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/in/johndoe"), true);
+    });
+
+    it("should allow linkedin.com/company/name", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/company/google"), true);
+    });
+
+    it("should allow linkedin.com/school/name", () => {
+      assert.strictEqual(validatePlatformUrl("linkedin", "https://www.linkedin.com/school/mit"), true);
+    });
+  });
 });

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -29,7 +29,7 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     x:          /^https?:\/\/(www\.)?(x|twitter)\.com\/[A-Za-z0-9_]{1,15}\/?(\?.*)?$/i,
 
     // Tightened to only allow public profile usernames or profile.php?id= format
-    facebook:   /^https?:\/\/(www\.)?facebook\.com\/(?!(?:gaming|watch|business|marketplace|groups|events|pages|help|policies|legal|about|login|checkpoint)\b)([A-Za-z0-9._-]{1,50}|profile\.php\?id=\d+)\/?(\?.*)?$/i,
+    facebook:   /^https?:\/\/(www\.)?facebook\.com\/(?!(?:gaming|watch|business|marketplace|groups|events|pages|help|policies|legal|about|login|checkpoint)\b)([A-Za-z0-9._-]{1,50}(?<!\.php)|profile\.php\?id=\d+)\/?(\?.*)?$/i,
 
     instagram:  /^https?:\/\/(www\.)?instagram\.com\/(?:[A-Za-z0-9._]{1,30}|p\/[A-Za-z0-9_-]+|reel\/[A-Za-z0-9_-]+|reels\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,
     discord:    /^https?:\/\/(www\.)?discord\.com\/(users\/\d{17,20}|invite\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -21,15 +21,17 @@ export type Platform =
 const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     github:     /^https?:\/\/(www\.)?github\.com\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
 
-    // Tightened to only allow public profile paths: /in/username or /company/name
+    // Tightened to only allow public profile paths: /in/username, /company/name, /school/name, /pub/username
     linkedin:   /^https?:\/\/(www\.)?linkedin\.com\/(in|company|school|pub)\/[A-Za-z0-9_-]+\/?(\?.*)?$/i,
 
     leetcode:   /^https?:\/\/(www\.)?leetcode\.com\/u\/[A-Za-z0-9_-]+\/?(\?.*)?$/i,
     youtube:    /^https?:\/\/(www\.)?(youtube\.com\/(@[A-Za-z0-9_.-]+|channel\/[A-Za-z0-9_-]+|c\/[A-Za-z0-9_-]+|shorts\/[A-Za-z0-9_-]+|watch|playlist)|youtu\.be\/[A-Za-z0-9_-]+\/?)\/?(\?.*)?$/i,
     x:          /^https?:\/\/(www\.)?(x|twitter)\.com\/[A-Za-z0-9_]{1,15}\/?(\?.*)?$/i,
 
-    // Tightened to only allow public profile usernames or profile.php?id= format
-    facebook:   /^https?:\/\/(www\.)?facebook\.com\/(?!(?:gaming|watch|business|marketplace|groups|events|pages|help|policies|legal|about|login|checkpoint)\b)([A-Za-z0-9._-]{1,50}(?<!\.php)|profile\.php\?id=\d+)\/?(\?.*)?$/i,
+    // Tightened to only allow profile.php?id= (checked first) or public usernames.
+    // profile.php?id=\d+ is listed before the username branch so the lookbehind
+    // never has a chance to misfire on the bare "profile.php" string.
+    facebook:   /^https?:\/\/(www\.)?facebook\.com\/(profile\.php\?id=\d+|(?!(?:gaming|watch|business|marketplace|groups|events|pages|help|policies|legal|about|login|checkpoint|messages)(?=[/?]|$))[A-Za-z0-9._-]{1,50})\/?(\?.*)?$/i,
 
     instagram:  /^https?:\/\/(www\.)?instagram\.com\/(?:[A-Za-z0-9._]{1,30}|p\/[A-Za-z0-9_-]+|reel\/[A-Za-z0-9_-]+|reels\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,
     discord:    /^https?:\/\/(www\.)?discord\.com\/(users\/\d{17,20}|invite\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,
@@ -42,10 +44,13 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
 };
 
 // ─── Platform Blocklists ─────────────────────────────────────────────────────
-// Catches unauthorized feeds, internal app views, and search frames right after domain mapping.
+// Defence-in-depth: catches internal app views even if the main pattern is ever loosened.
 const PLATFORM_BLOCKLIST: Partial<Record<Platform, RegExp>> = {
-    linkedin:  /\/(messaging|feed|jobs|notifications|search|mynetwork|learning|checkpoint|sales)\b/i,
-    facebook:  /\/(messaging|feed|groups|events|marketplace|gaming|watch|business|pages|help|policies|legal|about|login|checkpoint)\b/i,
+    // LinkedIn blocklist is kept as defence-in-depth even though the tightened
+    // pattern above already rejects anything outside /in|company|school|pub/.
+    linkedin:  /\/(messaging|feed|jobs|notifications|search|mynetwork|learning|checkpoint|sales)(?=[/?]|$)/i,
+    // Facebook blocklist uses (?=[/?]|$) instead of \b so trailing slashes are caught too.
+    facebook:  /\/(messaging|messages|feed|groups|events|marketplace|gaming|watch|business|pages|help|policies|legal|about|login|checkpoint)(?=[/?]|$)/i,
     youtube:   /\/results\b/i,
     instagram: /\/(explore|stories)\b/i,
 };

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -20,18 +20,17 @@ export type Platform =
 
 const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     github:     /^https?:\/\/(www\.)?github\.com\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
-    
-    // Catch-all domain suffixes force immediate platform identification for paths like /feed or /jobs,
-    // stopping links from bypassing validation filters as generic website URLs.
-    linkedin:   /^https?:\/\/(www\.)?linkedin\.com\/.*$/i,
-    
+
+    // Tightened to only allow public profile paths: /in/username or /company/name
+    linkedin:   /^https?:\/\/(www\.)?linkedin\.com\/(in|company|school|pub)\/[A-Za-z0-9_-]+\/?(\?.*)?$/i,
+
     leetcode:   /^https?:\/\/(www\.)?leetcode\.com\/u\/[A-Za-z0-9_-]+\/?(\?.*)?$/i,
     youtube:    /^https?:\/\/(www\.)?(youtube\.com\/(@[A-Za-z0-9_.-]+|channel\/[A-Za-z0-9_-]+|c\/[A-Za-z0-9_-]+|shorts\/[A-Za-z0-9_-]+|watch|playlist)|youtu\.be\/[A-Za-z0-9_-]+\/?)\/?(\?.*)?$/i,
     x:          /^https?:\/\/(www\.)?(x|twitter)\.com\/[A-Za-z0-9_]{1,15}\/?(\?.*)?$/i,
-    
-    // Generic domain catching ensures subpaths like /groups or /marketplace map to Facebook before validation.
-    facebook:   /^https?:\/\/(www\.)?facebook\.com\/.*$/i,
-    
+
+    // Tightened to only allow public profile usernames or profile.php?id= format
+    facebook:   /^https?:\/\/(www\.)?facebook\.com\/(?!(?:gaming|watch|business|marketplace|groups|events|pages|help|policies|legal|about|login|checkpoint)\b)([A-Za-z0-9._-]{1,50}|profile\.php\?id=\d+)\/?(\?.*)?$/i,
+
     instagram:  /^https?:\/\/(www\.)?instagram\.com\/(?:[A-Za-z0-9._]{1,30}|p\/[A-Za-z0-9_-]+|reel\/[A-Za-z0-9_-]+|reels\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,
     discord:    /^https?:\/\/(www\.)?discord\.com\/(users\/\d{17,20}|invite\/[A-Za-z0-9_-]+)\/?(\?.*)?$/i,
     twitch:     /^https?:\/\/(www\.)?twitch\.tv\/[A-Za-z0-9_]{4,25}\/?(\?.*)?$/i,
@@ -45,8 +44,8 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
 // ─── Platform Blocklists ─────────────────────────────────────────────────────
 // Catches unauthorized feeds, internal app views, and search frames right after domain mapping.
 const PLATFORM_BLOCKLIST: Partial<Record<Platform, RegExp>> = {
-    linkedin:  /\/(messaging|feed|jobs|notifications|search)\b/i,
-    facebook:  /\/(messaging|feed|groups|events|marketplace)\b/i,
+    linkedin:  /\/(messaging|feed|jobs|notifications|search|mynetwork|learning|checkpoint|sales)\b/i,
+    facebook:  /\/(messaging|feed|groups|events|marketplace|gaming|watch|business|pages|help|policies|legal|about|login|checkpoint)\b/i,
     youtube:   /\/results\b/i,
     instagram: /\/(explore|stories)\b/i,
 };

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -50,7 +50,7 @@ const PLATFORM_BLOCKLIST: Partial<Record<Platform, RegExp>> = {
     // pattern above already rejects anything outside /in|company|school|pub/.
     linkedin:  /\/(messaging|feed|jobs|notifications|search|mynetwork|learning|checkpoint|sales)(?=[/?]|$)/i,
     // Facebook blocklist uses (?=[/?]|$) instead of \b so trailing slashes are caught too.
-    facebook:  /\/(messaging|messages|feed|groups|events|marketplace|gaming|watch|business|pages|help|policies|legal|about|login|checkpoint)(?=[/?]|$)/i,
+    facebook:  /\/(messaging|messages|feed|groups|events|marketplace|gaming|watch|business|pages|help|policies|legal|about|login|checkpoint)(?=[/?]|$)|\/profile\.php(?!\?id=\d)/i,
     youtube:   /\/results\b/i,
     instagram: /\/(explore|stories)\b/i,
 };


### PR DESCRIPTION
## Summary
Fixes overly permissive URL validation for LinkedIn and Facebook platforms in `lib/platforms.ts`.

## Problem
Both LinkedIn and Facebook patterns used catch-all `.*` regexes that allowed any path under those domains to pass validation — including internal pages like `/feed`, `/jobs`, `/gaming`, `/watch` etc. that are inaccessible to visitors or resolve to a login wall.

## Changes Made

**`lib/platforms.ts`**

- **LinkedIn:** Tightened regex to only allow public profile paths (`/in/`, `/company/`, `/school/`, `/pub/`)
- **Facebook:** Tightened regex to only allow public usernames and `profile.php?id=` format
- **Blocklists:** Expanded both LinkedIn and Facebook blocklists to cover additional internal routes

## Before vs After

| Platform | Before | After |
|----------|--------|-------|
| LinkedIn | `linkedin.com/.*` | `linkedin.com/(in\|company\|school\|pub)/username` |
| Facebook | `facebook.com/.*` | `facebook.com/username` or `profile.php?id=` |

## URLs Now Blocked ❌
- `linkedin.com/feed`, `/jobs`, `/mynetwork`, `/learning`, `/checkpoint`
- `facebook.com/gaming`, `/watch`, `/marketplace`, `/business`, `/groups`

## URLs Still Allowed ✅
- `linkedin.com/in/johndoe`
- `linkedin.com/company/google`
- `facebook.com/johndoe`
- `facebook.com/profile.php?id=123456`

## Related Issue
Closes #324 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for LinkedIn and Facebook URLs to more strictly accept only public profile-related links.
  * Expanded protection to block additional restricted LinkedIn/Facebook post and feed-related paths, including trailing-slash variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->