### PR TITLE
fix: rate-limit the contact-us endpoint

### DIFF
--- a/app/api/contact-us/route.ts
+++ b/app/api/contact-us/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
 import { sendSupportEmail } from "@/lib/email";
+import { checkRateLimit } from "@/lib/rateLimit";
+
+const CONTACT_US_LIMIT = 5;
+const CONTACT_US_WINDOW_MS = 60 * 60 * 1000;
 
 function isValidEmail(value: unknown): value is string {
   return typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
@@ -15,6 +19,16 @@ function escapeHtml(value: string): string {
 }
 
 export async function POST(req: Request) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+
+  if (!checkRateLimit(`contact-us:${ip}`, CONTACT_US_LIMIT, CONTACT_US_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: "Too many requests. Please wait before trying again." },
+      { status: 429 },
+    );
+  }
+
   try {
     const body = await req.json();
     const name = typeof body?.name === "string" ? body.name.trim() : "";


### PR DESCRIPTION
## Summary
- `app/api/contact-us/route.ts` calls `sendSupportEmail` with no rate limiting, unlike `register`, `links`, `links/click`, and `user/send-delete-otp`, which all guard with `checkRateLimit`
- Without it, an attacker can hammer the endpoint to spam the configured `SUPPORT_EMAIL` inbox or abuse the underlying SMTP provider
- Adds the same `checkRateLimit(\`contact-us:${ip}\`, 5, 1h)` pattern already used by `app/api/auth/register/route.ts`

Fixes #352

## Test plan
- [x] Ran the app locally against a real Postgres instance (`prisma db push`) and a Next dev server
- [x] Sent 6 rapid requests from the same spoofed IP to `/api/contact-us`: first 5 returned `200`, the 6th returned `429 Too many requests`
- [x] Sent a request from a different IP immediately after — confirmed it was not blocked, proving the limit is scoped per-IP and doesn't affect other clients
- [x] `tsc --noEmit` shows no new errors introduced by this change (pre-existing errors elsewhere are unrelated, due to `@prisma/client` types not being generated without `DATABASE_URL`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request throttling to the contact form API to help prevent abuse and excessive submissions.
  * Returned a clear `429 Too Many Requests` response when the limit is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->