### PR TITLE
feat: add /api/health endpoint with database connectivity check

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+    try {
+        // Check database connectivity
+        await prisma.$queryRaw`SELECT 1`;
+
+        return NextResponse.json({
+            status: 'ok',
+            timestamp: new Date().toISOString(),
+            database: 'connected',
+        });
+    } catch (error) {
+        console.error('Health check failed:', error);
+        return NextResponse.json(
+            {
+                status: 'error',
+                timestamp: new Date().toISOString(),
+                database: 'disconnected',
+                error: error instanceof Error ? error.message : 'Unknown error',
+            },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,10 +1,24 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
+/**
+ * Health check endpoint.
+ * @returns {Promise<NextResponse>} JSON response with status, timestamp, and database connectivity.
+ */
 export async function GET() {
+    const timeoutMs = 5000; // 5 seconds
+
     try {
-        // Check database connectivity
-        await prisma.$queryRaw`SELECT 1`;
+        // Create a timeout promise that rejects after 5 seconds
+        const timeoutPromise = new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('Database query timeout')), timeoutMs)
+        );
+
+        // Race the DB query against the timeout
+        await Promise.race([
+            prisma.$queryRaw`SELECT 1`,
+            timeoutPromise,
+        ]);
 
         return NextResponse.json({
             status: 'ok',
@@ -12,13 +26,16 @@ export async function GET() {
             database: 'connected',
         });
     } catch (error) {
+        // Log the full error server-side for debugging
         console.error('Health check failed:', error);
+
+        // Return a generic message to the client (hide internal details)
         return NextResponse.json(
             {
                 status: 'error',
                 timestamp: new Date().toISOString(),
                 database: 'disconnected',
-                error: error instanceof Error ? error.message : 'Unknown error',
+                error: 'Database connection failed. Please try again later.',
             },
             { status: 500 }
         );


### PR DESCRIPTION
## Addresses Task 4 from Issue #354

This PR adds a `/api/health` endpoint that:
- Returns `status: "ok"` and a timestamp.
- Checks database connectivity via `SELECT 1`.
- Returns `status: "error"` with details if the database is unreachable.

This is the first step towards the enhancements proposed in #354. The remaining tasks (rate limiting, password policy, indexes, constants, account deletion) will be addressed in separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new health-check endpoint that returns the app’s status and a timestamp.
  * The endpoint also reports whether the database connection is available.
* **Bug Fixes**
  * Improved error handling for health checks so failures return a clear error response and HTTP 500 status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->