### PR TITLE
feat: add database indexes for performance (Task 3)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
+  provider = "postgresql"
 }
 
 model User {
@@ -32,6 +32,8 @@ model User {
   profileVersions ProfileVersion[]
   previewTokens ProfilePreviewToken[]
   createdAt     DateTime @default(now())
+
+  @@index([username])
 }
 
 model UserAlias {
@@ -43,9 +45,6 @@ model UserAlias {
 
   @@index([userId])
 }
-
-
-
 
 model Link {
   id        String   @id @default(uuid())
@@ -63,6 +62,8 @@ model Link {
   updatedAt DateTime @updatedAt
 
   @@unique([userId, platform])
+  @@index([userId])
+  @@index([platform])
 }
 
 model ClickEvent {
@@ -133,6 +134,7 @@ model AccountMergeEvent {
   @@index([sourceUserId])
   @@index([targetUserId, createdAt])
 }
+
 model Account {
   id                String  @id @default(cuid())
   userId            String


### PR DESCRIPTION
## Addresses Task 3 from Issue #354

This PR adds database indexes to improve query performance:
- `User.username` – for faster username lookups
- `Link.userId` – for faster user-specific link queries
- `Link.platform` – for faster platform-based filtering

These indexes will help the application scale as the dataset grows.

**Local testing:** Verified with `npx prisma db push` and confirmed indexes exist in PostgreSQL.