### PR TITLE
perf(analytics): paginate click history export with cursor batching

### DIFF
--- a/app/api/analytics/export/route.ts
+++ b/app/api/analytics/export/route.ts
@@ -2,6 +2,58 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+// Click history is exported in bounded batches instead of a single
+// unbounded findMany. A link with tens of thousands of clicks would
+// otherwise force the whole table into memory and onto the wire in one
+// shot. Cursor pagination on `id` keeps each query and each emitted chunk
+// small regardless of how large the underlying click history has grown.
+const EXPORT_BATCH_SIZE = 1000;
+
+type ExportClick = Prisma.ClickEventGetPayload<{ include: { link: true } }>;
+
+function escapeCSV(value: string | null | undefined): string {
+    if (value == null) return "";
+    const str = String(value);
+    if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+        return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+}
+
+function clickToCSVRow(c: ExportClick): string {
+    return [
+        escapeCSV(c.createdAt.toISOString()),
+        escapeCSV(c.link?.label ?? ""),
+        escapeCSV(c.link?.url ?? ""),
+        escapeCSV(c.referrer),
+        escapeCSV(c.country),
+        escapeCSV(c.deviceType),
+        escapeCSV(c.userAgent),
+    ].join(",");
+}
+
+async function* iterateClicksInBatches(userId: string): AsyncGenerator<ExportClick[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+        const batch: ExportClick[] = await prisma.clickEvent.findMany({
+            where: { userId },
+            orderBy: { id: "asc" },
+            take: EXPORT_BATCH_SIZE,
+            ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+            include: { link: true },
+        });
+
+        if (batch.length === 0) return;
+
+        yield batch;
+
+        if (batch.length < EXPORT_BATCH_SIZE) return;
+        cursor = batch[batch.length - 1].id;
+    }
+}
 
 export async function GET(req: NextRequest) {
     const session = await getServerSession(authOptions);
@@ -9,50 +61,34 @@ export async function GET(req: NextRequest) {
         return new NextResponse("Unauthorized", { status: 401 });
     }
 
+    const userId = session.user.id;
     const { searchParams } = new URL(req.url);
     const format = searchParams.get("format") ?? "csv";
 
-    // Fetch click history with link data for the authenticated user
-    const clicks = await prisma.clickEvent.findMany({
-        where: {
-            userId: session.user.id,
-        },
-        orderBy: {
-            createdAt: "desc",
-        },
-        include: {
-            link: true,
-        },
-    });
-
     if (format === "csv") {
-        // CSV field escaping: wrap in quotes and escape internal quotes and newlines
-        const escapeCSV = (value: string | null | undefined): string => {
-            if (value == null) return "";
-            const str = String(value);
-            if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
-                return `"${str.replace(/"/g, '""')}"`;
-            }
-            return str;
-        };
-
+        const encoder = new TextEncoder();
         const header = "Timestamp,Link Label,URL,Referrer,Country,Device Type,User Agent\r\n";
 
-        const rows = clicks.map((c) =>
-            [
-                escapeCSV(c.createdAt.toISOString()),
-                escapeCSV(c.link?.label ?? ""),
-                escapeCSV(c.link?.url ?? ""),
-                escapeCSV(c.referrer),
-                escapeCSV(c.country),
-                escapeCSV(c.deviceType),
-                escapeCSV(c.userAgent),
-            ].join(",")
-        );
+        const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+                controller.enqueue(encoder.encode(header));
 
-        const csvContent = header + rows.join("\r\n");
+                let isFirstRow = true;
+                try {
+                    for await (const batch of iterateClicksInBatches(userId)) {
+                        const rows = batch.map(clickToCSVRow);
+                        const chunk = (isFirstRow ? "" : "\r\n") + rows.join("\r\n");
+                        controller.enqueue(encoder.encode(chunk));
+                        isFirstRow = false;
+                    }
+                    controller.close();
+                } catch (error) {
+                    controller.error(error);
+                }
+            },
+        });
 
-        return new NextResponse(csvContent, {
+        return new NextResponse(stream, {
             status: 200,
             headers: {
                 "Content-Type": "text/csv; charset=utf-8",
@@ -61,6 +97,24 @@ export async function GET(req: NextRequest) {
         });
     }
 
-    // Default: return JSON
-    return NextResponse.json({ clicks });
+    // JSON format: paginate with a cursor so a single request can't be used
+    // to pull an unbounded number of rows into memory.
+    const limitParam = searchParams.get("limit");
+    const cursorParam = searchParams.get("cursor");
+
+    const limit = Math.max(1, Math.min(2000, limitParam ? Number.parseInt(limitParam, 10) || 500 : 500));
+
+    const clicks = await prisma.clickEvent.findMany({
+        where: { userId },
+        orderBy: { id: "asc" },
+        take: limit + 1,
+        ...(cursorParam ? { skip: 1, cursor: { id: cursorParam } } : {}),
+        include: { link: true },
+    });
+
+    const hasMore = clicks.length > limit;
+    const page = hasMore ? clicks.slice(0, limit) : clicks;
+    const nextCursor = hasMore ? page[page.length - 1].id : null;
+
+    return NextResponse.json({ clicks: page, nextCursor });
 }


### PR DESCRIPTION
⚠️ **Important:** This project is part of **GSSoC'26** and **NSoC'26**.
All contributors must select their organization below and include it in their PR title.
PRs without an organization tag may not be reviewed.

## 🏢 Organization
- [x] GirlScript Summer of Code 2026 (GSSoC'26)
- [ ] Nexus Spring of Code 2026 (NSoC'26)
- [ ] None (General contribution)

## 📋 Summary

The click analytics export endpoint (`GET /api/analytics/export`) loaded a user's entire `ClickEvent` history with a single unbounded `findMany` before serializing it to CSV or JSON. For a link with tens of thousands of clicks, this meant the whole click log for that user was pulled into memory and held there for the duration of the request, exactly the failure mode described in this issue.

This PR replaces the single unbounded query with cursor-based batch iteration:

- **CSV export**: rows are fetched in batches of 1000 (ordered by `id`, cursor-paginated) and streamed to the response as each batch is produced, via a `ReadableStream`. Memory usage stays bounded no matter how large the click history is, since no more than one batch is ever held in memory at a time.
- **JSON export**: now accepts `limit` (default 500, max 2000) and `cursor` query params and returns `{ clicks, nextCursor }` instead of the full unbounded array, so a single request can no longer be used to pull unlimited rows into memory.

I verified the only caller of this route (`AnalyticsOverview.tsx`'s CSV export button, which reads the response as a blob) is unaffected by the streaming response or the JSON response shape change, since the JSON path isn't currently consumed by the frontend.

The dashboard's main analytics summary (`/api/analytics/summary`, backed by `getUserAnalyticsSummary` in `lib/analytics.ts`) was already using pre-aggregated `DailyLinkAnalytics` rows with SQL-level `groupBy`/`aggregate`, so that path did not need changes. The unbounded query was isolated to the export route's raw click log fetch.

## 🔗 Related Issue

Closes #348

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔗 New platform support
- [ ] ♻️ Refactor (no feature or bug change)
- [ ] 📝 Documentation update
- [ ] 🎨 UI / Styling change
- [x] ⚡ Performance fix

## 🧪 How to Test

1. Seed a user with a large number of `ClickEvent` rows for a single link (e.g. 20k+) via Prisma Studio or a script
2. Go to the dashboard, open the export dropdown, click "Export to CSV"
3. Verify the CSV downloads successfully and contains all rows, without the request hanging or the server's memory usage spiking
4. Hit `GET /api/analytics/export?format=json&limit=500` directly and confirm the response is `{ clicks: [...], nextCursor: "<id>" }` with at most 500 rows; pass `cursor=<nextCursor>` to confirm the next page continues correctly
5. Confirm a user with zero clicks still gets a valid (header-only) CSV and `{ clicks: [], nextCursor: null }` for JSON

## 📸 Screenshots

Not applicable — this is a backend/API change with no UI changes.

## ✅ Checklist

**Code Quality**
- [x] My branch is up to date with `main`
- [x] `npm run lint` passes with no errors (pre-existing, unrelated error in `app/components/ScrollReveal.tsx` on `main` is untouched by this PR)
- [x] `npm run build` completes successfully
- [x] No `console.log` statements left in the code
- [x] No new TypeScript errors introduced

**Changes**
- [x] I have manually tested my changes in the browser
- [ ] I tested on both desktop and mobile viewport (not applicable, API-only change)
- [ ] I tested in both light mode and dark mode (not applicable, no UI change)
- [x] I tested edge cases (empty click history, exact-batch-size boundary, pagination cursor continuation)

**Platform Addition** *(skip if not applicable)*
- Not applicable

**Documentation**
- [ ] I have updated the README if needed (not applicable, internal API behavior only)
- [x] I have added comments to complex logic

## 💬 Additional Notes

No breaking changes for existing consumers: the CSV export (the only endpoint currently wired into the UI) still returns the same content type and full file, just streamed instead of buffered. The JSON format's response shape changed from a flat `{ clicks }` array to a paginated `{ clicks, nextCursor }` shape, but this format isn't currently called from the frontend, so nothing existing breaks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported analytics data now streams CSV results for faster, more memory-efficient downloads.
  * Added pagination for JSON exports, with `limit` and `cursor` support for easier page-by-page retrieval.

* **Bug Fixes**
  * Improved large export handling to reduce the risk of slow or failed downloads when dealing with many click records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->