### PR TITLE
fix(redirect): revalidate URL scheme before issuing platform redirect

### DIFF
--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -8,6 +8,7 @@ import { trackLinkClick } from "@/lib/analytics";
 import { resolveUserByUsername } from "@/lib/userLookup";
 // ✨ Fixed: Correct module reference target mapping
 import { getMobileOS, getDeepLink } from "@/lib/deeplink";
+import { isSafeRedirectUrl } from "@/lib/urlValidation";
 
 // ✨ Platform package registry mapping fallback for Android Intents
 const ANDROID_PACKAGES: Record<string, string> = {
@@ -54,7 +55,16 @@ export default async function PlatformRedirect({
 
     if (!link) notFound();
 
-    // Track analytics asynchronously safely 
+    // Revalidate the redirect target's scheme even though it was already
+    // checked when the link was created or updated. `link.url` below is
+    // rendered into a `<meta http-equiv="refresh">` tag, an inline script,
+    // an `<a href>`, and passed to `redirect()` — a `javascript:`, `data:`,
+    // or otherwise non-http(s) value must never reach any of those sinks.
+    if (!isSafeRedirectUrl(link.url)) {
+        notFound();
+    }
+
+    // Track analytics asynchronously safely
     await trackLinkClick({
         linkId: link.id,
         userId: link.userId,

--- a/lib/urlValidation.test.ts
+++ b/lib/urlValidation.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSafeRedirectUrl } from "@/lib/urlValidation";
+
+test("isSafeRedirectUrl accepts http URLs", () => {
+    assert.equal(isSafeRedirectUrl("http://example.com"), true);
+});
+
+test("isSafeRedirectUrl accepts https URLs", () => {
+    assert.equal(isSafeRedirectUrl("https://example.com/path?query=1"), true);
+});
+
+test("isSafeRedirectUrl rejects javascript: URIs", () => {
+    assert.equal(isSafeRedirectUrl("javascript:alert(document.cookie)"), false);
+});
+
+test("isSafeRedirectUrl rejects data: URIs", () => {
+    assert.equal(isSafeRedirectUrl("data:text/html,<script>alert(1)</script>"), false);
+});
+
+test("isSafeRedirectUrl rejects file: URIs", () => {
+    assert.equal(isSafeRedirectUrl("file:///etc/passwd"), false);
+});
+
+test("isSafeRedirectUrl rejects scheme-less values", () => {
+    assert.equal(isSafeRedirectUrl("example.com"), false);
+});
+
+test("isSafeRedirectUrl rejects empty or malformed strings", () => {
+    assert.equal(isSafeRedirectUrl(""), false);
+    assert.equal(isSafeRedirectUrl("not a url"), false);
+});
+
+test("isSafeRedirectUrl does not reject deceptive-looking but valid https URLs (host validation is handled at write time)", () => {
+    assert.equal(isSafeRedirectUrl("https://legitimate.com.attacker.com"), true);
+});

--- a/lib/urlValidation.ts
+++ b/lib/urlValidation.ts
@@ -1,3 +1,22 @@
+/**
+ * Defense-in-depth check applied at redirect time, in addition to the
+ * scheme validation already performed in `validateUrlBackend` when a link
+ * is created or updated. Redirect targets are read straight from the
+ * database and passed to `redirect()`, a `<meta http-equiv="refresh">` tag,
+ * and an inline deep-link script, so any `javascript:`, `data:`, `file:`,
+ * or scheme-less value reaching that point (whether from a future write
+ * path that forgets to validate, or from data written before validation
+ * existed) must be rejected before it's ever rendered or navigated to.
+ */
+export function isSafeRedirectUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
 export function validateUrl(url: string): { valid: true } | { valid: false; error: string } {
     const trimmed = url.trim();
     if (!trimmed) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "node scripts/postinstall-prisma-generate.mjs",
     "migrate:deploy:safe": "node scripts/safe-prisma-migrate-deploy.mjs",
     "lint": "eslint",
-    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts lib/analytics.test.ts lib/accountMergeUtils.test.ts lib/imageValidation.test.ts"
+    "test": "tsx --test lib/csrf.test.ts lib/middleware/csrf.test.ts lib/analytics.test.ts lib/accountMergeUtils.test.ts lib/imageValidation.test.ts lib/urlValidation.test.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",


### PR DESCRIPTION
⚠️ **Important:** This project is part of **GSSoC'26** and **NSoC'26**.
All contributors must select their organization below and include it in their PR title.
PRs without an organization tag may not be reviewed.

## 🏢 Organization
- [x] GirlScript Summer of Code 2026 (GSSoC'26)
- [ ] Nexus Spring of Code 2026 (NSoC'26)
- [ ] None (General contribution)

## 📋 Summary

Link creation (`POST /api/links`) and updates (`PATCH /api/links/[id]`) already validate a submitted URL's scheme via `validateUrlBackend` in `lib/urlValidation.ts`, rejecting anything that isn't `http:`/`https:` and blocking private/loopback IPs. That part of this issue's root cause was already handled.

The gap was at redirect time. `app/[username]/[platform]/page.tsx` fetches `link.url` straight from the database and passes it, unchecked, into four separate sinks:

- `redirect(webUrl)` (Next.js navigation)
- `<meta http-equiv="refresh" content={`3;url=${webUrl}`} />`
- an inline `<script>` that sets `window.location.href`
- `<a href={webUrl}>Open in browser instead</a>`

Since this handler trusts whatever is currently stored in `Link.url` with no revalidation, any `javascript:`, `data:`, or scheme-less value that ever reached the database (a future write path that forgets to call `validateUrlBackend`, a direct DB write, or a row from before validation existed) would be rendered and navigated to without a second check — exactly the "validated at creation time and at redirect time" requirement called out in this issue.

## Fix

- Added `isSafeRedirectUrl(url)` to `lib/urlValidation.ts` — a minimal scheme-only check (`http:`/`https:`) intended specifically for this redirect-time revalidation. It's deliberately narrower than `validateUrlBackend` (no private-IP/hostname checks) since those only need to be enforced once, at write time; this is a last-line-of-defense gate before rendering.
- `PlatformRedirect` now calls `isSafeRedirectUrl(link.url)` immediately after loading the link and calls `notFound()` if it fails, before any of the four sinks above are constructed.
- Added `lib/urlValidation.test.ts` covering `http:`/`https:` acceptance, rejection of `javascript:`, `data:`, `file:`, and scheme-less strings, and confirming that deceptive-but-valid hostnames like `https://legitimate.com.attacker.com` are correctly left to hostname-level validation (which already runs at write time) rather than this scheme check.
- Wired the new test file into the existing `npm test` script (`tsx --test ...`), matching the project's existing Node test-runner convention.

## 🔗 Related Issue

Closes #347

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔗 New platform support
- [ ] ♻️ Refactor (no feature or bug change)
- [ ] 📝 Documentation update
- [ ] 🎨 UI / Styling change

## 🧪 How to Test

1. Run `npm test` and confirm all `isSafeRedirectUrl` cases pass
2. Create a link normally through the UI and confirm the profile redirect (`/username/platform`) still works as before
3. Using Prisma Studio (or a direct DB write), set a `Link.url` value to `javascript:alert(1)`, bypassing the app's own creation/update validation
4. Visit that link's public redirect URL and confirm it now renders a 404 instead of executing the script or attempting a `meta refresh`/redirect to it
5. Confirm links with normal `https://` URLs still redirect correctly, including the mobile deep-link interstitial path

## 📸 Screenshots

Not applicable — this is a backend validation change; the only user-visible difference is that a link with a malicious stored URL now 404s instead of executing.

## ✅ Checklist

**Code Quality**
- [x] My branch is up to date with `main`
- [x] `npm run lint` passes with no errors (pre-existing, unrelated error in `app/components/ScrollReveal.tsx` on `main` is untouched by this PR)
- [x] `npm run build` completes successfully
- [x] No `console.log` statements left in the code
- [x] No new TypeScript errors introduced

**Changes**
- [x] I have manually tested my changes in the browser
- [ ] I tested on both desktop and mobile viewport (not applicable, no UI change beyond a 404 fallback)
- [ ] I tested in both light mode and dark mode (not applicable, no UI change)
- [x] I tested edge cases (`javascript:`, `data:`, `file:`, scheme-less, empty, deceptive-domain URLs)

**Platform Addition** *(skip if not applicable)*
- Not applicable

**Documentation**
- [ ] I have updated the README if needed (not applicable, internal security fix)
- [x] I have added comments to complex logic

## 💬 Additional Notes

No breaking changes: every link created or updated through the app's own API already passes `validateUrlBackend` and will continue to pass this new redirect-time check without any behavior change. This only affects URLs that bypassed write-time validation.
