### PR TITLE
feat(analytics): decouple redirect from synchronous DB writes via job queuing

### DIFF
--- a/app/api/jobs/analytics/route.ts
+++ b/app/api/jobs/analytics/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { claimNextJob, markJobCompleted, markJobFailed } from "@/lib/jobs";
+import { processAnalyticsJob } from "@/lib/analytics";
+import type { Prisma } from "@prisma/client";
+
+const BATCH_SIZE = 50;
+const MAX_PROCESSING_TIME_MS = 50_000;
+
+type AnalyticsJobPayload = {
+    linkId: string;
+    userId: string;
+    userAgent: string | null;
+    referrer: string | null;
+    country: string | null;
+    acceptLanguage: string | null;
+    ip: string | null;
+};
+
+export async function POST(req: Request) {
+    const authHeader = req.headers.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const startTime = Date.now();
+    let processed = 0;
+    let failed = 0;
+
+    try {
+        while (Date.now() - startTime < MAX_PROCESSING_TIME_MS && processed < BATCH_SIZE) {
+            const job = await claimNextJob();
+            if (!job) break;
+
+            if (job.type !== "analytics-click") {
+                await markJobCompleted(job.id);
+                continue;
+            }
+
+            try {
+                const payload = job.payload as Prisma.JsonValue as AnalyticsJobPayload;
+                await processAnalyticsJob(payload);
+                await markJobCompleted(job.id);
+                processed++;
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                await markJobFailed(job.id, message);
+                failed++;
+            }
+        }
+
+        return NextResponse.json({
+            processed,
+            failed,
+            durationMs: Date.now() - startTime,
+        });
+    } catch (err) {
+        console.error("[analytics-worker] Fatal error:", err);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/jobs/analytics/route.ts
+++ b/app/api/jobs/analytics/route.ts
@@ -1,22 +1,12 @@
 import { NextResponse } from "next/server";
-import { claimNextJob, markJobCompleted, markJobFailed } from "@/lib/jobs";
-import { processAnalyticsJob } from "@/lib/analytics";
+import { claimNextJob, releaseJob, markJobCompleted, markJobFailed } from "@/lib/jobs";
+import { processAnalyticsJob, type AnalyticsJobPayload } from "@/lib/analytics";
 import type { Prisma } from "@prisma/client";
 
 const BATCH_SIZE = 50;
 const MAX_PROCESSING_TIME_MS = 50_000;
 
-type AnalyticsJobPayload = {
-    linkId: string;
-    userId: string;
-    userAgent: string | null;
-    referrer: string | null;
-    country: string | null;
-    acceptLanguage: string | null;
-    ip: string | null;
-};
-
-export async function POST(req: Request) {
+async function handleRequest(req: Request) {
     const authHeader = req.headers.get("authorization");
     const cronSecret = process.env.CRON_SECRET;
 
@@ -30,13 +20,8 @@ export async function POST(req: Request) {
 
     try {
         while (Date.now() - startTime < MAX_PROCESSING_TIME_MS && processed < BATCH_SIZE) {
-            const job = await claimNextJob();
+            const job = await claimNextJob("analytics-click");
             if (!job) break;
-
-            if (job.type !== "analytics-click") {
-                await markJobCompleted(job.id);
-                continue;
-            }
 
             try {
                 const payload = job.payload as Prisma.JsonValue as AnalyticsJobPayload;
@@ -62,4 +47,12 @@ export async function POST(req: Request) {
             { status: 500 }
         );
     }
+}
+
+export async function POST(req: Request) {
+    return handleRequest(req);
+}
+
+export async function GET(req: Request) {
+    return handleRequest(req);
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -17,7 +17,7 @@ type TrackClickInput = {
     headers: Headers;
 };
 
-type AnalyticsJobPayload = {
+export type AnalyticsJobPayload = {
     linkId: string;
     userId: string;
     userAgent: string | null;

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { enqueueJob } from "@/lib/jobs";
 import {
     detectDeviceType,
     getForwardedIp,
@@ -16,6 +17,16 @@ type TrackClickInput = {
     headers: Headers;
 };
 
+type AnalyticsJobPayload = {
+    linkId: string;
+    userId: string;
+    userAgent: string | null;
+    referrer: string | null;
+    country: string | null;
+    acceptLanguage: string | null;
+    ip: string | null;
+};
+
 export async function trackLinkClick(input: TrackClickInput): Promise<void> {
     const { linkId, userId, headers } = input;
 
@@ -24,6 +35,23 @@ export async function trackLinkClick(input: TrackClickInput): Promise<void> {
     const country = headers.get("x-vercel-ip-country") ?? headers.get("cf-ipcountry");
     const acceptLanguage = headers.get("accept-language");
     const ip = getForwardedIp(headers);
+
+    const jobPayload: AnalyticsJobPayload = {
+        linkId,
+        userId,
+        userAgent,
+        referrer,
+        country,
+        acceptLanguage,
+        ip,
+    };
+
+    await enqueueJob("analytics-click", jobPayload);
+}
+
+export async function processAnalyticsJob(payload: AnalyticsJobPayload): Promise<void> {
+    const { linkId, userId, userAgent, referrer, country, acceptLanguage, ip } = payload;
+
     const isBot = isLikelyBot(userAgent);
     const deviceType = detectDeviceType(userAgent);
     const visitorKey = isBot

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -36,23 +36,40 @@ export async function markJobFailed(id: string, error?: string) {
   });
 }
 
+export async function releaseJob(id: string) {
+  return prisma.job.update({
+    where: { id },
+    data: { status: "PENDING", updatedAt: new Date() },
+  });
+}
+
 // Polling-based worker helper: finds the next eligible job and marks it processing.
-export async function claimNextJob() {
+// Optionally filter by job type. If a non-matching job is found first, it is left
+// untouched so other workers can process it.
+export async function claimNextJob(type?: string) {
   const now = new Date();
-  // find a pending or scheduled job whose runAfter is null or in the past
+  const where: Prisma.JobWhereInput = type
+    ? {
+        type,
+        OR: [
+          { status: "PENDING" },
+          { status: "SCHEDULED", runAfter: { lte: now } },
+        ],
+      }
+    : {
+        OR: [
+          { status: "PENDING" },
+          { status: "SCHEDULED", runAfter: { lte: now } },
+        ],
+      };
+
   const job = await prisma.job.findFirst({
-    where: {
-      OR: [
-        { status: "PENDING" },
-        { status: "SCHEDULED", runAfter: { lte: now } },
-      ],
-    },
+    where,
     orderBy: { createdAt: "asc" },
   });
 
   if (!job) return null;
 
-  // try to atomically mark processing
   try {
     const claimed = await prisma.job.update({
       where: { id: job.id },
@@ -84,6 +101,7 @@ const jobs = {
   enqueueJob,
   getJob,
   claimNextJob,
+  releaseJob,
   processJobWithHandler,
 };
 

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,10 +1,23 @@
 import "../lib/prisma";
 import { claimNextJob, processJobWithHandler, type JobPayload } from "../lib/jobs";
+import { processAnalyticsJob } from "../lib/analytics";
 
-// Example handlers: extend this map with your application's heavy tasks
+type AnalyticsJobPayload = {
+    linkId: string;
+    userId: string;
+    userAgent: string | null;
+    referrer: string | null;
+    country: string | null;
+    acceptLanguage: string | null;
+    ip: string | null;
+};
+
 const handlers: Record<string, (payload: JobPayload) => Promise<void>> = {
+  "analytics-click": async (payload) => {
+    const data = payload as unknown as AnalyticsJobPayload;
+    await processAnalyticsJob(data);
+  },
   "send-email": async (payload) => {
-    // placeholder: integrate with real email provider
     console.log("[worker] send-email", payload);
   },
   "recalculate-analytics": async (payload) => {

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,16 +1,6 @@
 import "../lib/prisma";
 import { claimNextJob, processJobWithHandler, type JobPayload } from "../lib/jobs";
-import { processAnalyticsJob } from "../lib/analytics";
-
-type AnalyticsJobPayload = {
-    linkId: string;
-    userId: string;
-    userAgent: string | null;
-    referrer: string | null;
-    country: string | null;
-    acceptLanguage: string | null;
-    ip: string | null;
-};
+import { processAnalyticsJob, type AnalyticsJobPayload } from "../lib/analytics";
 
 const handlers: Record<string, (payload: JobPayload) => Promise<void>> = {
   "analytics-click": async (payload) => {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/jobs/analytics",
-      "schedule": "* * * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/jobs/analytics",
+      "schedule": "* * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implemented asynchronous link analytics processing using the existing job queue.

### Changes

- enqueue analytics jobs instead of synchronous DB writes
- background processing via cron endpoint
- no schema changes required
- preserved existing tracking API
- improved redirect performance

Closes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Analytics click tracking is now processed asynchronously via a background job queue.
  * A scheduled cron job processes analytics updates every minute.
  * The worker now supports an analytics-click job pathway for handling queued analytics.

* **Bug Fixes**
  * Improved analytics job execution with batching and processing time limits.
  * Added stricter protection for the analytics job endpoint using a required authorization header, with clear error handling for unauthorized/failing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->