### PR TITLE
Add Remember Me functionality to login form

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,64 @@
 import NextAuth from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
 
-const handler = NextAuth(authOptions);
+const handler = async (req: NextRequest, ctx: { params: Promise<{ nextauth: string[] }> }) => {
+  let rememberMe = false;
+  const pathname = req.nextUrl.pathname;
+
+  if (req.method === "POST" && pathname.endsWith("/signin/credentials")) {
+    try {
+      const contentType = req.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        const clone = req.clone();
+        const body = await clone.json();
+        rememberMe = body.rememberMe === "true" || body.rememberMe === true;
+      } else {
+        const clone = req.clone();
+        const formData = await clone.formData();
+        rememberMe = formData.get("rememberMe") === "true";
+      }
+
+      const cookieStore = await cookies();
+      cookieStore.set("remember-me", rememberMe ? "true" : "false", {
+        maxAge: rememberMe ? 30 * 24 * 60 * 60 : 24 * 60 * 60,
+        path: "/",
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+      });
+    } catch (e) {
+      console.error("Error parsing form data in auth wrapper:", e);
+    }
+  } else if (pathname.includes("/callback/")) {
+    // Default OAuth logins to be remembered (30 days)
+    rememberMe = true;
+    const cookieStore = await cookies();
+    cookieStore.set("remember-me", "true", {
+      maxAge: 30 * 24 * 60 * 60,
+      path: "/",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+    });
+  } else if (req.method === "POST" && pathname.endsWith("/signout")) {
+    const cookieStore = await cookies();
+    cookieStore.delete("remember-me");
+  } else {
+    const cookieStore = await cookies();
+    rememberMe = cookieStore.get("remember-me")?.value === "true";
+  }
+
+  const maxAge = rememberMe ? 30 * 24 * 60 * 60 : 24 * 60 * 60;
+
+  return NextAuth(req, ctx, {
+    ...authOptions,
+    session: {
+      ...authOptions.session,
+      maxAge,
+    },
+  });
+};
 
 export { handler as GET, handler as POST };

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -17,31 +17,15 @@ const handler = async (req: NextRequest, ctx: { params: Promise<{ nextauth: stri
       } else {
         const clone = req.clone();
         const formData = await clone.formData();
-        rememberMe = formData.get("rememberMe") === "true";
+        const remVal = formData.get("rememberMe");
+        rememberMe = remVal === "true" || remVal === "on";
       }
-
-      const cookieStore = await cookies();
-      cookieStore.set("remember-me", rememberMe ? "true" : "false", {
-        maxAge: rememberMe ? 30 * 24 * 60 * 60 : 24 * 60 * 60,
-        path: "/",
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-      });
     } catch (e) {
       console.error("Error parsing form data in auth wrapper:", e);
     }
-  } else if (pathname.includes("/callback/")) {
+  } else if (pathname.includes("/callback/") && !pathname.endsWith("/callback/credentials")) {
     // Default OAuth logins to be remembered (30 days)
     rememberMe = true;
-    const cookieStore = await cookies();
-    cookieStore.set("remember-me", "true", {
-      maxAge: 30 * 24 * 60 * 60,
-      path: "/",
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-    });
   } else if (req.method === "POST" && pathname.endsWith("/signout")) {
     const cookieStore = await cookies();
     cookieStore.delete("remember-me");

--- a/app/components/ScrollReveal.tsx
+++ b/app/components/ScrollReveal.tsx
@@ -15,6 +15,7 @@ export function ScrollReveal({ children, className, delay = 0 }: ScrollRevealPro
 
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisible(true);
       return;
     }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import Credentials from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import bcrypt from "bcryptjs";
 import type { NextAuthOptions } from "next-auth";
+import { cookies } from "next/headers";
 
 import prisma from "@/lib/prisma";
 import { isUserSessionInvalidated } from "@/lib/sessionInvalidation";
@@ -59,6 +60,7 @@ export const authOptions: NextAuthOptions = {
             credentials: {
                 email: { label: "Email", type: "email" },
                 password: { label: "Password", type: "password" },
+                rememberMe: { label: "Remember Me", type: "text" },
             },
 
             async authorize(credentials) {
@@ -94,6 +96,29 @@ events: {
     },
 },
     callbacks: {
+        async signIn({ account, credentials }) {
+            const cookieStore = await cookies();
+            if (account?.provider === "credentials" && credentials) {
+                const rememberMe = credentials.rememberMe === "true" || credentials.rememberMe === true || credentials.rememberMe === "on";
+                cookieStore.set("remember-me", rememberMe ? "true" : "false", {
+                    maxAge: rememberMe ? 30 * 24 * 60 * 60 : 24 * 60 * 60,
+                    path: "/",
+                    httpOnly: true,
+                    secure: process.env.NODE_ENV === "production",
+                    sameSite: "lax",
+                });
+            } else if (account?.provider && account.provider !== "credentials") {
+                // Default OAuth logins to be remembered (30 days)
+                cookieStore.set("remember-me", "true", {
+                    maxAge: 30 * 24 * 60 * 60,
+                    path: "/",
+                    httpOnly: true,
+                    secure: process.env.NODE_ENV === "production",
+                    sameSite: "lax",
+                });
+            }
+            return true;
+        },
         async jwt({ token, trigger, session, user, account, profile }) {
             // Immediately invalidate token if user account was deleted
             if (token.sub && (await isUserSessionInvalidated(token.sub))) {


### PR DESCRIPTION
Adds a "Remember Me" option to the login form for persistent user sessions.



## Program Participation
I am contributing under **EcSOc 2026**.
<img width="1397" height="660" alt="image" src="https://github.com/user-attachments/assets/9d71fb33-dcc7-4879-8d0a-9fb42f913ea0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Remember me” support for credential sign-ins, allowing sessions to remain active for up to 30 days when selected.
  * Sessions without “Remember me” now expire after 24 hours.
  * OAuth sign-ins automatically receive an extended 30-day session.
  * Signing out now clears the “Remember me” preference.

* **Chores**
  * Updated code-quality configuration without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->