### PR TITLE
fix: handle unexpected errors in OTP rate limiter

### DIFF
--- a/lib/deleteOtpStore.ts
+++ b/lib/deleteOtpStore.ts
@@ -101,8 +101,13 @@ export async function checkRateLimit(userId: string): Promise<boolean> {
         create: { userId, sendCount: 1, windowStart: now }
       });
       return true;
-    } catch {
-      // Ignore creation race condition
+    } catch (err: unknown) {
+      // Ignore creation race condition (Unique constraint failed)
+      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
+        // Safe to proceed as the record was created by a concurrent request
+      } else {
+        throw err;
+      }
     }
   }
 

--- a/lib/deleteOtpStore.ts
+++ b/lib/deleteOtpStore.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 
@@ -103,7 +104,7 @@ export async function checkRateLimit(userId: string): Promise<boolean> {
       return true;
     } catch (err: unknown) {
       // Ignore creation race condition (Unique constraint failed)
-      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
         // Safe to proceed as the record was created by a concurrent request
       } else {
         throw err;


### PR DESCRIPTION
## Summary

This PR improves error handling in `checkRateLimit()`.

### Changes
- Handle only the expected Prisma `P2002` race-condition error.
- Rethrow unexpected database and Prisma errors instead of silently ignoring them.
- Prevent execution from continuing after an unexpected `upsert()` failure.

### Problem

Previously, every error thrown by `prisma.deleteOtp.upsert()` was ignored. If the failure was caused by anything other than the expected race condition, execution continued to `prisma.deleteOtp.update()`, which could result in an unhandled exception.

### Solution

The catch block now ignores only the expected unique-constraint race condition (`P2002`) and rethrows all other errors.

Fixes #380 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during rate-limit record creation.
  * Unique-constraint conflicts continue to be handled automatically, while other errors are now surfaced for proper diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->