### PR TITLE
Fix active alias hijacking on version rollback (#390)

### DIFF
--- a/lib/profileWorkflow.test.ts
+++ b/lib/profileWorkflow.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mock, test, before } from "node:test";
+
+let mockVersion: any = null;
+let mockCurrentUser: any = null;
+let mockClaimingUser: any = null;
+let mockAlias: any = null;
+
+const mockTx = {
+  profileVersion: {
+    findUnique: () => Promise.resolve(mockVersion),
+    create: () => Promise.resolve({}),
+  },
+  user: {
+    findUnique: (args: any) => {
+      if (args.where.id) {
+        return Promise.resolve(mockCurrentUser);
+      }
+      if (args.where.username) {
+        return Promise.resolve(mockClaimingUser);
+      }
+      return Promise.resolve(null);
+    },
+    update: () => Promise.resolve({}),
+  },
+  userAlias: {
+    findUnique: (args: any) => {
+      return Promise.resolve(mockAlias);
+    },
+    upsert: () => Promise.resolve({}),
+  },
+  profileDraft: {
+    deleteMany: () => Promise.resolve({}),
+  },
+  profilePreviewToken: {
+    updateMany: () => Promise.resolve({}),
+  },
+};
+
+mock.module("@/lib/prisma", {
+  namedExports: {
+    prisma: {
+      $transaction: (fn: any) => fn(mockTx),
+    },
+  },
+});
+
+let rollbackProfileVersion: any;
+
+before(async () => {
+  const workflow = await import("@/lib/profileWorkflow");
+  rollbackProfileVersion = workflow.rollbackProfileVersion;
+});
+
+test("rollback succeeds when username is unchanged", async () => {
+  mockVersion = {
+    id: "version-1",
+    userId: "user-A",
+    name: "User A",
+    username: "coolprofile",
+    bio: "old bio",
+    image: null,
+  };
+  mockCurrentUser = {
+    id: "user-A",
+    name: "User A",
+    username: "coolprofile",
+    bio: "new bio",
+    image: null,
+  };
+  mockClaimingUser = null;
+  mockAlias = null;
+
+  const result = await rollbackProfileVersion("user-A", "version-1");
+  assert.equal(result.snapshot.username, "coolprofile");
+  assert.deepEqual(result.diff.bio, { before: "new bio", after: "old bio" });
+});
+
+test("rollback fails when target username is claimed by another user as primary username", async () => {
+  mockVersion = {
+    id: "version-1",
+    userId: "user-A",
+    name: "User A",
+    username: "coolprofile",
+    bio: "old bio",
+    image: null,
+  };
+  mockCurrentUser = {
+    id: "user-A",
+    name: "User A",
+    username: "differentprofile",
+    bio: "new bio",
+    image: null,
+  };
+  // User B has claimed "coolprofile"
+  mockClaimingUser = {
+    id: "user-B",
+    username: "coolprofile",
+  };
+  mockAlias = null;
+
+  await assert.rejects(
+    rollbackProfileVersion("user-A", "version-1"),
+    (err: Error) => {
+      assert.equal(err.message, "The username in this profile version is no longer available.");
+      return true;
+    }
+  );
+});
+
+test("rollback fails when target username is claimed by another user as an alias", async () => {
+  mockVersion = {
+    id: "version-1",
+    userId: "user-A",
+    name: "User A",
+    username: "coolprofile",
+    bio: "old bio",
+    image: null,
+  };
+  mockCurrentUser = {
+    id: "user-A",
+    name: "User A",
+    username: "differentprofile",
+    bio: "new bio",
+    image: null,
+  };
+  mockClaimingUser = null;
+  // User B owns the alias "coolprofile"
+  mockAlias = {
+    id: "alias-1",
+    username: "coolprofile",
+    userId: "user-B",
+  };
+
+  await assert.rejects(
+    rollbackProfileVersion("user-A", "version-1"),
+    (err: Error) => {
+      assert.equal(err.message, "The username in this profile version is no longer available.");
+      return true;
+    }
+  );
+});
+
+test("rollback succeeds when target username is an alias owned by the same user", async () => {
+  mockVersion = {
+    id: "version-1",
+    userId: "user-A",
+    name: "User A",
+    username: "coolprofile",
+    bio: "old bio",
+    image: null,
+  };
+  mockCurrentUser = {
+    id: "user-A",
+    name: "User A",
+    username: "differentprofile",
+    bio: "new bio",
+    image: null,
+  };
+  mockClaimingUser = null;
+  // User A owns the alias "coolprofile" (it's their own alias)
+  mockAlias = {
+    id: "alias-1",
+    username: "coolprofile",
+    userId: "user-A",
+  };
+
+  const result = await rollbackProfileVersion("user-A", "version-1");
+  assert.equal(result.snapshot.username, "coolprofile");
+});

--- a/lib/profileWorkflow.ts
+++ b/lib/profileWorkflow.ts
@@ -167,10 +167,12 @@ function diffProfileSnapshots(
  */
 export async function isProfileUsernameAvailable(
   username: string,
-  excludeUserId?: string
+  excludeUserId?: string,
+  tx?: TransactionClient | typeof prisma
 ): Promise<boolean> {
+  const db = tx || prisma;
   // Check if username is taken
-  const user = await prisma.user.findUnique({
+  const user = await db.user.findUnique({
     where: { username },
   });
 
@@ -179,7 +181,7 @@ export async function isProfileUsernameAvailable(
   }
 
   // Check if username is an alias — but allow the user to reclaim their own alias
-  const alias = await prisma.userAlias.findUnique({
+  const alias = await db.userAlias.findUnique({
     where: { username },
   });
 
@@ -435,7 +437,18 @@ export async function rollbackProfileVersion(
 
     // Handle username change
     if (beforeSnapshot.username && beforeSnapshot.username !== afterSnapshot.username) {
+      if (afterSnapshot.username) {
+        const isAvailable = await isProfileUsernameAvailable(afterSnapshot.username, userId, tx);
+        if (!isAvailable) {
+          throw new Error("The username in this profile version is no longer available.");
+        }
+      }
       await ensureUsernameAliases(tx, userId, beforeSnapshot.username);
+    } else if (afterSnapshot.username && afterSnapshot.username !== beforeSnapshot.username) {
+      const isAvailable = await isProfileUsernameAvailable(afterSnapshot.username, userId, tx);
+      if (!isAvailable) {
+        throw new Error("The username in this profile version is no longer available.");
+      }
     }
 
     // Update the live profile


### PR DESCRIPTION
### Description
Closes #390 

This PR resolves a security vulnerability in the profile version rollback functionality where a user's primary username could be updated to a previously used username from their history without performing any availability checks. This was causing database unique constraint violations (if claimed by another user as a primary username) or silent data collisions (if claimed by another user as an active alias).

### Key Changes
* **`lib/profileWorkflow.ts`**:
  * Updated the helper `isProfileUsernameAvailable` function to optionally accept a database transaction client (`tx`). This allows checking availability transactionally, protecting against TOCTOU (Time-of-Check to Time-of-Use) races.
  * Added a check in `rollbackProfileVersion` before updating the user's profile. If the target rollback username is different from their current username, we perform a transactional availability check.
  * If the username is already claimed (either as a primary username or as an active alias by another user), we now block the rollback and throw a clean validation error: `"The username in this profile version is no longer available."`.
* **`lib/profileWorkflow.test.ts`**:
  * Added unit tests to cover and assert all scenarios:
    1. Successful rollback when the username is unchanged.
    2. Blocked rollback with a clean error when the username is claimed by another user as their primary username.
    3. Blocked rollback with a clean error when the username is claimed by another user as an active alias.
    4. Successful rollback when the username is currently an alias owned by the same user (reclaiming their own alias).

### Verification
* Ran the new test suite using:
  ```bash
  node --import tsx --test --experimental-test-module-mocks lib/profileWorkflow.test.ts
  ```

All 4 rollback test cases passed successfully.

Ran the complete existing test suite using npm test (all 39 test cases passed with no regressions).


***

### Summary of Completed Work
1. **Branch Created & Pushed:** Created and checked out the new branch `fix/rollback-alias-hijacking`. Successfully pushed it to your origin repository.
2. **Code Modified:** Made `isProfileUsernameAvailable` transaction-aware and integrated the availability check in `rollbackProfileVersion` inside `lib/profileWorkflow.ts`.
3. **Tests Added:** Created a comprehensive test suite `lib/profileWorkflow.test.ts` and successfully verified all conditions.
4. **Plans & Documentation:** Created the [implementation_plan.md](file:///C:/Users/ADMIN/.gemini/antigravity-ide/brain/c1f3589c-10ff-4bac-89e0-1abae69cc613/implementation_plan.md) and [walkthrough.md](file:///C:/Users/ADMIN/.gemini/antigravity-ide/brain/c1f3589c-10ff-4bac-89e0-1abae69cc613/walkthrough.md) artifacts to track implementation and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile version rollbacks by rechecking username availability before restoring a previous username.
  * Prevented rollbacks when the username is claimed by another account or used as another account’s alias.
  * Allowed rollbacks when the username remains available or is already an alias of the same account.

* **Tests**
  * Added coverage for successful and rejected username rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->