### PR TITLE
fix: atomic job claiming with FOR UPDATE SKIP LOCKED (#397)

### DIFF
--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -46,39 +46,49 @@ export async function releaseJob(id: string) {
 // Polling-based worker helper: finds the next eligible job and marks it processing.
 // Optionally filter by job type. If a non-matching job is found first, it is left
 // untouched so other workers can process it.
+//
+// Uses an atomic UPDATE ... WHERE id = (SELECT ... FOR UPDATE SKIP LOCKED LIMIT 1)
+// query to prevent the race condition where multiple concurrent workers could
+// claim and process the same job (see issue #397).
 export async function claimNextJob(type?: string) {
   const now = new Date();
-  const where: Prisma.JobWhereInput = type
-    ? {
-        type,
-        OR: [
-          { status: "PENDING" },
-          { status: "SCHEDULED", runAfter: { lte: now } },
-        ],
-      }
-    : {
-        OR: [
-          { status: "PENDING" },
-          { status: "SCHEDULED", runAfter: { lte: now } },
-        ],
-      };
 
-  const job = await prisma.job.findFirst({
-    where,
-    orderBy: { createdAt: "asc" },
-  });
+  // Build the type filter clause conditionally
+  const typeFilter = type ? Prisma.sql`AND "type" = ${type}` : Prisma.empty;
 
-  if (!job) return null;
+  // Atomic claim: the subquery locks the first eligible row with FOR UPDATE
+  // SKIP LOCKED, which means concurrent workers will skip already-locked rows
+  // and claim the next available job instead of waiting or double-claiming.
+  const result = await prisma.$queryRaw<Array<{
+    id: string;
+    type: string;
+    payload: Prisma.JsonValue;
+    status: string;
+    scheduleAt: Date | null;
+    attempts: number;
+    lastError: string | null;
+    runAfter: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }>>`
+    UPDATE "Job"
+    SET "status" = 'PROCESSING', "updatedAt" = NOW()
+    WHERE "id" = (
+      SELECT "id"
+      FROM "Job"
+      WHERE (
+        "status" = 'PENDING'
+        OR ("status" = 'SCHEDULED' AND "runAfter" <= ${now})
+      )
+      ${typeFilter}
+      ORDER BY "createdAt" ASC
+      LIMIT 1
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING *
+  `;
 
-  try {
-    const claimed = await prisma.job.update({
-      where: { id: job.id },
-      data: { status: "PROCESSING", updatedAt: new Date() },
-    });
-    return claimed;
-  } catch {
-    return null;
-  }
+  return result.length > 0 ? result[0] : null;
 }
 
 type JobRecord = { id: string; type: string; payload: Prisma.JsonValue };


### PR DESCRIPTION
## Summary

Fixes #397 — Double-Processing Claiming Race Condition in Jobs Worker.

### Problem

`claimNextJob` in `lib/jobs.ts` used two separate, non-atomic database operations:

1. `findFirst` to query the next pending job
2. `update` to set its status to `PROCESSING`

In multi-worker environments, two workers could execute `findFirst` concurrently, both reading the same pending job before either updates it. Both workers would then mark it as `PROCESSING` and execute it, causing duplicate side effects (e.g., duplicate emails, double-counted analytics).

### Solution

Replaced the two-step read-then-write with a **single atomic PostgreSQL query**:

```sql
UPDATE "Job"
SET "status" = 'PROCESSING', "updatedAt" = NOW()
WHERE "id" = (
  SELECT "id" FROM "Job"
  WHERE ("status" = 'PENDING' OR ("status" = 'SCHEDULED' AND "runAfter" <= $1))
  ORDER BY "createdAt" ASC
  LIMIT 1
  FOR UPDATE SKIP LOCKED
)
RETURNING *
```

**`FOR UPDATE SKIP LOCKED`** ensures:
- The selected row is **exclusively locked** within the subquery — no other transaction can claim it
- Concurrent workers **skip locked rows** instead of waiting, moving to the next available job
- The entire find-and-claim operation is a **single atomic statement** — no window for a race condition

### Changes

- **`lib/jobs.ts`** — Rewrote `claimNextJob` to use `prisma.$queryRaw` with an atomic `UPDATE ... RETURNING` + `FOR UPDATE SKIP LOCKED` subquery

### Testing

- TypeScript compilation passes (no new errors introduced)
- The function signature and return type are unchanged — all existing callers (`scripts/worker.ts`, `app/api/jobs/analytics/route.ts`) work without modification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job claiming reliability by preventing multiple workers from claiming the same job.
  * Ensured scheduled jobs are claimed only after their scheduled time.
  * Added consistent handling when no eligible jobs are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->