### PR TITLE
fix: add /dashboard routes to middleware matcher for auth protection (#398)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,9 +8,14 @@ export async function middleware(req: NextRequest) {
     const token = await getToken({ req });
     const { pathname } = req.nextUrl;
 
-    // If logged in & trying to access /login → redirect
+    // If logged in & trying to access /login or /register → redirect to dashboard
     if (token && (pathname === "/login" || pathname === "/register")) {
         return NextResponse.redirect(new URL("/dashboard", req.url));
+    }
+
+    // If NOT logged in & trying to access /dashboard → redirect to login (#398)
+    if (!token && pathname.startsWith("/dashboard")) {
+        return NextResponse.redirect(new URL("/login", req.url));
     }
 
     const csrfResponse = await applyCsrfProtection(req);
@@ -23,5 +28,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-    matcher: ["/login", "/register", "/api/:path*"],
+    matcher: ["/login", "/register", "/dashboard/:path*", "/api/:path*"],
 };


### PR DESCRIPTION
## Summary

Fixes #398 — Middleware Matcher Excludes `/dashboard` Routes, Leaving Them Unprotected by Default.

### Problem

The middleware `config.matcher` in `middleware.ts` only included:
```ts
matcher: ["/login", "/register", "/api/:path*"]
```

This completely omitted `/dashboard` and all its sub-routes (`/dashboard/settings`, etc.). As a result, unauthenticated requests to any dashboard page were **not intercepted at the Edge/routing level**. If a developer creates a new page under `/dashboard` and forgets to add a page-level session guard, that page is fully accessible to the public.

### Solution

**Two changes to `middleware.ts`:**

1. **Added `"/dashboard/:path*"` to the matcher** so the middleware now runs on all dashboard routes:
```ts
matcher: ["/login", "/register", "/dashboard/:path*", "/api/:path*"]
```

2. **Added unauthenticated redirect logic** — if a user without a valid session token accesses any `/dashboard` route, they are immediately redirected to `/login`:
```ts
if (!token && pathname.startsWith("/dashboard")) {
    return NextResponse.redirect(new URL("/login", req.url));
}
```

This provides defense-in-depth: dashboard routes are now protected at both the Edge middleware level **and** at the page level (via existing `getServerSession` checks).

### Changes

- **`middleware.ts`** — Added `/dashboard/:path*` to matcher + unauthenticated redirect to `/login`

### Testing

- Unauthenticated access to `/dashboard` → redirected to `/login` ✅
- Unauthenticated access to `/dashboard/settings` → redirected to `/login` ✅
- Authenticated access to `/dashboard` → allowed through ✅
- Authenticated access to `/login` → redirected to `/dashboard` (existing behavior preserved) ✅
- API routes and CSRF protection → unaffected ✅
