### PR TITLE
fix: resolve global rate limit reset vulnerability (#396)

### DIFF
--- a/lib/rateLimit.test.ts
+++ b/lib/rateLimit.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkRateLimit } from "@/lib/rateLimit";
+
+test("Global Rate Limit Reset Vulnerability check", async () => {
+    // Ensure we are testing the in-memory backend by having UPSTASH_REDIS env variables unset
+    const oldUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const oldToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    try {
+        const longWindowKey = "test:endpointA:1.2.3.4";
+        const shortWindowKey = "test:endpointB:1.2.3.4";
+
+        const longWindowMs = 24 * 60 * 60 * 1000; // 24 hours
+        const shortWindowMs = 60000; // 1 minute
+
+        // 1. Consume rate limit on longWindowKey (limit = 2)
+        const allowed1 = await checkRateLimit(longWindowKey, 2, longWindowMs);
+        const allowed2 = await checkRateLimit(longWindowKey, 2, longWindowMs);
+        const allowed3 = await checkRateLimit(longWindowKey, 2, longWindowMs);
+
+        assert.equal(allowed1, true, "First request to long window should be allowed");
+        assert.equal(allowed2, true, "Second request to long window should be allowed");
+        assert.equal(allowed3, false, "Third request to long window should be blocked");
+
+        // 2. Make 500 requests to shortWindowKey to trigger sweepExpiredKeys()
+        // since CLEANUP_INTERVAL is 500.
+        for (let i = 0; i < 500; i++) {
+            await checkRateLimit(shortWindowKey, 1000, shortWindowMs);
+        }
+
+        // 3. Verify that the rate limit for longWindowKey has NOT been reset/swept away
+        const allowedAfterSweep = await checkRateLimit(longWindowKey, 2, longWindowMs);
+        assert.equal(allowedAfterSweep, false, "Long window request should still be blocked after sweep");
+    } finally {
+        // Restore environment variables
+        if (oldUrl) process.env.UPSTASH_REDIS_REST_URL = oldUrl;
+        if (oldToken) process.env.UPSTASH_REDIS_REST_TOKEN = oldToken;
+    }
+});

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -28,6 +28,7 @@
 
 type WindowEntry = {
     timestamps: number[];
+    windowMs: number;
 };
 
 const store = new Map<string, WindowEntry>();
@@ -39,9 +40,10 @@ const store = new Map<string, WindowEntry>();
 let requestsSinceCleanup = 0;
 const CLEANUP_INTERVAL = 500; // sweep after every N requests
 
-function sweepExpiredKeys(windowMs: number): void {
-    const cutoff = Date.now() - windowMs;
+function sweepExpiredKeys(): void {
+    const now = Date.now();
     for (const [key, entry] of store.entries()) {
+        const cutoff = now - entry.windowMs;
         if (entry.timestamps.every((t) => t <= cutoff)) {
             store.delete(key);
         }
@@ -59,13 +61,15 @@ function checkRateLimitMemory(
     requestsSinceCleanup++;
     if (requestsSinceCleanup >= CLEANUP_INTERVAL) {
         requestsSinceCleanup = 0;
-        sweepExpiredKeys(windowMs);
+        sweepExpiredKeys();
     }
 
     let entry = store.get(key);
     if (!entry) {
-        entry = { timestamps: [] };
+        entry = { timestamps: [], windowMs };
         store.set(key, entry);
+    } else {
+        entry.windowMs = windowMs;
     }
 
     // Evict timestamps outside the current window.


### PR DESCRIPTION
## Summary

Fixes #396 — Global Rate Limit Reset Vulnerability.

### Problem

In in-memory rate limiting mode, the global rate limiter kept track of request timestamps inside a shared `Map` store:
```ts
type WindowEntry = {
    timestamps: number[];
};
const store = new Map<string, WindowEntry>();
```

During a clean-up sweep (`sweepExpiredKeys(windowMs)`), it calculated the expiration cutoff based on the *currently executing request's* `windowMs`:
```ts
const cutoff = Date.now() - windowMs;
for (const [key, entry] of store.entries()) {
    if (entry.timestamps.every((t) => t <= cutoff)) {
        store.delete(key);
    }
}
```

If Endpoint A had a long rate-limit window (e.g. 24 hours) and Endpoint B had a short window (e.g. 1 minute), any request to Endpoint B triggered a sweep using the 1-minute window. This sweep incorrectly identified Endpoint A's entries (which were older than 1 minute but newer than 24 hours) as expired and deleted them. Attackers could exploit this to bypass long rate limits on sensitive endpoints by repeatedly calling short-window endpoints to trigger clean-up sweeps.

### Solution

Associated each rate-limiting entry with its own specific `windowMs` configuration:
1. Updated `WindowEntry` type to store `windowMs` alongside timestamps:
   ```ts
   type WindowEntry = {
       timestamps: number[];
       windowMs: number;
   };
   ```
2. Saved `windowMs` to the store in `checkRateLimitMemory`.
3. Updated `sweepExpiredKeys` to evaluate every key against its own specific `windowMs` TTL rather than using the caller's parameter:
   ```ts
   function sweepExpiredKeys(): void {
       const now = Date.now();
       for (const [key, entry] of store.entries()) {
           const cutoff = now - entry.windowMs;
           if (entry.timestamps.every((t) => t <= cutoff)) {
               store.delete(key);
           }
       }
   }
   ```
4. Added a dedicated regression test suite in `lib/rateLimit.test.ts` to assert that short-window sweeps do not reset rate limits on long-window keys.

### Changes

- **`lib/rateLimit.ts`** — Updated in-memory rate limiter structures and sweep logic to prevent premature entry eviction.
- **`lib/rateLimit.test.ts`** — Added regression unit tests covering the vulnerability.

### Testing

- Ran `npm test` and verified that all 80 tests pass successfully.
- Validated that TypeScript compiler yields no errors.
