### PR TITLE
feat(api): expose profile version history and rollback API routes

### DIFF
--- a/app/api/profile/versions/[id]/rollback/route.ts
+++ b/app/api/profile/versions/[id]/rollback/route.ts
@@ -30,6 +30,26 @@ export async function POST(
     }
 
     const { id: versionId } = await params;
+
+    const version = await prisma.profileVersion.findUnique({
+      where: { id: versionId },
+      select: { userId: true },
+    });
+
+    if (!version) {
+      return NextResponse.json(
+        { error: "Version not found" },
+        { status: 404 }
+      );
+    }
+
+    if (version.userId !== user.id) {
+      return NextResponse.json(
+        { error: "Access denied" },
+        { status: 403 }
+      );
+    }
+
     const { snapshot, diff } = await rollbackProfileVersion(user.id, versionId);
 
     return NextResponse.json(
@@ -44,11 +64,9 @@ export async function POST(
     console.error("Profile rollback error:", error);
     const message =
       error instanceof Error ? error.message : "Failed to rollback profile";
-    const isNotFound =
-      error instanceof Error && error.message === "Version not found or access denied";
     return NextResponse.json(
       { error: message },
-      { status: isNotFound ? 404 : 500 }
+      { status: 500 }
     );
   }
 }

--- a/app/components/ScrollReveal.tsx
+++ b/app/components/ScrollReveal.tsx
@@ -15,6 +15,7 @@ export function ScrollReveal({ children, className, delay = 0 }: ScrollRevealPro
 
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisible(true);
       return;
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const nextJest = require('next/jest')
 
 const createJestConfig = nextJest({


### PR DESCRIPTION
## ✨ Feature Description
Expose the existing profile versioning and rollback business logic via proper API routes so the frontend can access profile version history and trigger rollbacks.

Close #401 

## 🤔 Problem It Solves
The `getProfileVersions()` and `rollbackProfileVersion()` functions were already fully implemented in `lib/profileWorkflow.ts`, but were unreachable from the UI because there were no API routes connecting them to the frontend, making the feature effectively dead code.

## 💡 Solution Implemented
Ensured two API route handlers are implemented and conform to requirements:
- **`GET /api/profile/versions`** — Returns the authenticated user's profile version history (list of snapshots with diffs and timestamps).
- **`POST /api/profile/versions/[id]/rollback`** — Rolls back the authenticated user's live profile to the specified version snapshot. Explicit authorization checks were added to ensure users can only roll back to their own versions.

## 🎯 Acceptance Criteria Satisfied
- [x] `GET /api/profile/versions` returns the user's version history
- [x] `POST /api/profile/versions/[id]/rollback` rolls back to the specified version
- [x] Unauthenticated requests return `401`
- [x] Attempting to rollback another user's version returns `403`
- [x] No TypeScript errors (`npm run lint` passes)
