### PR TITLE
fix: invalidate sessions before account deletion

### DIFF
--- a/app/api/user/delete/route.test.ts
+++ b/app/api/user/delete/route.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mock, test, before } from "node:test";
+import bcrypt from "bcryptjs";
+
+let mockSession: unknown = null;
+let mockUser: unknown = null;
+const callOrder: string[] = [];
+
+mock.module("next-auth", {
+  exports: {
+    getServerSession: () => Promise.resolve(mockSession),
+  },
+});
+
+mock.module("@/lib/auth", {
+  exports: { authOptions: {} },
+});
+
+mock.module("@/lib/prisma", {
+  exports: {
+    default: {
+      user: {
+        findUnique: () => Promise.resolve(mockUser),
+        delete: () => {
+          callOrder.push("deleteUser");
+          return Promise.resolve({});
+        },
+      },
+    },
+    prisma: {
+      user: {
+        findUnique: () => Promise.resolve(mockUser),
+        delete: () => {
+          callOrder.push("deleteUser");
+          return Promise.resolve({});
+        },
+      },
+    },
+  },
+});
+
+mock.module("@/lib/deleteOtpStore", {
+  exports: {
+    verifyOtp: () => Promise.resolve({ valid: true }),
+    clearOtp: () => {
+      callOrder.push("clearOtp");
+      return Promise.resolve({});
+    },
+  },
+});
+
+mock.module("@/lib/sessionInvalidation", {
+  exports: {
+    invalidateUserSessions: () => {
+      callOrder.push("invalidateUserSessions");
+      return Promise.resolve({});
+    },
+  },
+});
+
+// Mock the compare method on the shared bcryptjs instance
+mock.method(bcrypt, "compare", () => Promise.resolve(true));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let DELETE: (...args: any[]) => Promise<Response>;
+
+before(async () => {
+  const route = await import("@/app/api/user/delete/route");
+  DELETE = route.DELETE;
+});
+
+function deleteRequest(body: unknown): Request {
+  return new Request("http://localhost/api/user/delete", {
+    method: "DELETE",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("DELETE 401 — no session", async () => {
+  mockSession = null;
+  const res = await DELETE(deleteRequest({ otp: "123456" }));
+  assert.equal(res.status, 401);
+});
+
+test("DELETE 200 — performs cleanups and deletes user in the correct order", async () => {
+  mockSession = { user: { id: "test-user-id" } };
+  mockUser = { id: "test-user-id", password: "hashedpassword", email: "user@example.com" };
+  callOrder.length = 0;
+
+  const res = await DELETE(deleteRequest({ password: "password123", otp: "123456" }));
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { success: true });
+  assert.deepEqual(callOrder, ["invalidateUserSessions", "clearOtp", "deleteUser"]);
+});

--- a/app/api/user/delete/route.ts
+++ b/app/api/user/delete/route.ts
@@ -63,11 +63,11 @@ export async function DELETE(req: NextRequest) {
     }
 
 
+    await invalidateUserSessions(userId);
+    await clearOtp(userId);
     await prisma.user.delete({
       where: { id: session.user.id },
     });
-    await invalidateUserSessions(userId);
-    await clearOtp(userId);
 
     return NextResponse.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
*## Fixes Issue

Fixes #419 

## Description

This PR fixes the account deletion workflow by reordering the cleanup operations. Previously, `invalidateUserSessions()` and `clearOtp()` were executed after `prisma.user.delete()`, causing session invalidation to fail because the user record had already been removed. As a result, active JWT sessions could remain valid until expiration.

The cleanup operations are now performed before deleting the user, ensuring sessions are properly invalidated, OTP records are cleared, and the account deletion process completes without foreign key constraint errors.

## Type of change

* 🐛 Bug fix
* ☐ 💡 New feature
* ☐ 📖 Documentation update
* ☐ 💭 Other (please specify):

## Checklist

* [x] I am an ECSoC'26 contributor
* [x] My code follows the project’s style guidelines.
* [x] I have added comments in areas that may be hard to understand.
* [x] I have NOT included `package.json` or `package-lock.json` in this PR.


### Bug Fixes

* Reordered the account deletion workflow to invalidate user sessions before deleting the user record.
* Ensured OTP cleanup occurs before account deletion.
* Prevented foreign key constraint failures during session invalidation.
* Improved the reliability and security of the account deletion process by ensuring active sessions are properly invalidated before the account is removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deletion reliability by invalidating active sessions and clearing verification data before removing the account.
  * Enhanced protection against unauthorized account deletion attempts.

* **Tests**
  * Added coverage for authenticated and unauthenticated account deletion scenarios, including verification of cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->