### PR TITLE
Fix/overlap buttons

### DIFF
--- a/app/components/TourHelpButton.tsx
+++ b/app/components/TourHelpButton.tsx
@@ -7,7 +7,7 @@ export default function TourHelpButton() {
         localStorage.removeItem("linkid_tour_done");
         window.location.reload();
       }}
-      className="fixed bottom-20 right-6 z-50 rounded-full bg-violet-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-violet-500"
+      className="fixed bottom-[72px] right-6 z-50 rounded-full bg-violet-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-violet-500"
     >
       Start Tour
     </button>

--- a/app/components/TourHelpButton.tsx
+++ b/app/components/TourHelpButton.tsx
@@ -7,7 +7,7 @@ export default function TourHelpButton() {
         localStorage.removeItem("linkid_tour_done");
         window.location.reload();
       }}
-      className="fixed bottom-6 right-6 z-50 rounded-full bg-violet-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-violet-500"
+      className="fixed bottom-20 right-6 z-50 rounded-full bg-violet-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-violet-500"
     >
       Start Tour
     </button>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Description
This pull request resolves an issue where the **Start Tour** button and the **Back to Top** button overlapped when both were visible at the bottom-right corner of the viewport.

The vertical position of the **Start Tour** button has been adjusted so they stack cleanly, leaving a clear and visually consistent spacing.

### Changes
* Modified `app/components/TourHelpButton.tsx` to change positioning class from `bottom-6` to `bottom-[72px]`.
* Spacing details:
  * **Back to Top Button**: Offset `bottom-6` (`24px`) + size `h-10` (`40px`) = top of the button is at `64px`.
  * **Start Tour Button**: Offset `bottom-[72px]` (`72px`).
  * **Resulting Gap**: Exactly `8px` (`0.5rem`) between the two elements.

## Verification
* Validated that Next.js development server runs cleanly.
* Verified that both buttons render without overlapping when the user scrolls the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the “Start Tour” button’s position so it appears higher on the page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->