### PR TITLE
feat: custom aliases for multiple accounts of the same platform (#431)

### DIFF
--- a/app/[username]/ProfileLinkItem.tsx
+++ b/app/[username]/ProfileLinkItem.tsx
@@ -20,7 +20,7 @@ export function ProfileLinkItem({ link, username }: ProfileLinks) {
 
     return (
         <a
-            href={`/${username}/${link.platform}`}
+            href={`/${username}/${link.alias || link.platform}`}
             target="_blank"
             rel="noopener noreferrer"
             aria-label={ariaLabel}

--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -46,11 +46,14 @@ export default async function PlatformRedirect({
 
     const link = await prisma.link.findFirst({
         where: {
-            platform: normalizedPlatform, // Pass lowercased string safely
             userId: resolved.user.id,
             isPublic: true,
+            OR: [
+                { alias: normalizedPlatform },
+                { platform: normalizedPlatform, alias: null }
+            ]
         },
-        select: { id: true, url: true, userId: true },
+        select: { id: true, url: true, userId: true, platform: true },
     });
 
     if (!link) notFound();
@@ -77,7 +80,8 @@ export default async function PlatformRedirect({
     const webUrl = link.url;
 
     if (os !== "unknown") {
-        const deepLinks = getDeepLink(normalizedPlatform, webUrl);
+        const actualPlatform = link.platform;
+        const deepLinks = getDeepLink(actualPlatform, webUrl);
         let appUrl = os === "android" ? deepLinks.android : deepLinks.ios;
 
         if (appUrl) {
@@ -86,7 +90,7 @@ export default async function PlatformRedirect({
             
             if (os === "android" && isInApp) {
                 const cleanUrl = webUrl.replace(/^https?:\/\//, "");
-                const targetPackage = ANDROID_PACKAGES[normalizedPlatform];
+                const targetPackage = ANDROID_PACKAGES[actualPlatform];
                 
                 // ✨ Fixed: Safe registry mapping check to skip wrong fake package layouts
                 if (targetPackage) {
@@ -133,7 +137,7 @@ export default async function PlatformRedirect({
                             `,
                         }}
                     />
-                    <p>Opening {platform} app...</p>
+                    <p>Opening {actualPlatform} app...</p>
                     <a href={webUrl}>Open in browser instead</a>
                 </div>
             );

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -3,6 +3,7 @@ export type Link = {
     id: string;
     createdAt: Date;
     platform: string;
+    alias?: string | null;
     url: string;
     position: number;
     clicks: number;

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -122,6 +122,28 @@ export async function PUT(
     return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
   }
 
+  // Enforce uniqueness for the resulting route if platform is changing
+  if (data.platform) {
+      const proposedRoute = link.alias || data.platform;
+      const existingLink = await prisma.link.findFirst({
+          where: {
+              userId: link.userId,
+              id: { not: link.id },
+              OR: [
+                  { alias: proposedRoute },
+                  { platform: proposedRoute, alias: null }
+              ]
+          }
+      });
+
+      if (existingLink) {
+          return NextResponse.json(
+              { error: `The route '/${proposedRoute}' is already in use.` },
+              { status: 409 }
+          );
+      }
+  }
+
   try {
     const updatedLink = await prisma.link.update({
       where: { id },

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -122,36 +122,43 @@ export async function PUT(
     return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
   }
 
-  // Enforce uniqueness for the resulting route if platform is changing
-  if (data.platform) {
-      const proposedRoute = link.alias || data.platform;
-      const existingLink = await prisma.link.findFirst({
-          where: {
-              userId: link.userId,
-              id: { not: link.id },
-              OR: [
-                  { alias: proposedRoute },
-                  { platform: proposedRoute, alias: null }
-              ]
-          }
-      });
-
-      if (existingLink) {
-          return NextResponse.json(
-              { error: `The route '/${proposedRoute}' is already in use.` },
-              { status: 409 }
-          );
-      }
-  }
-
   try {
-    const updatedLink = await prisma.link.update({
-      where: { id },
-      data,
+    const updatedLink = await prisma.$transaction(async (tx) => {
+        // Enforce uniqueness for the resulting route if platform is changing
+        if (data.platform) {
+            const proposedRoute = link.alias || data.platform;
+            const existingLink = await tx.link.findFirst({
+                where: {
+                    userId: link.userId,
+                    id: { not: link.id },
+                    OR: [
+                        { alias: proposedRoute },
+                        { platform: proposedRoute, alias: null }
+                    ]
+                }
+            });
+
+            if (existingLink) {
+                throw Object.assign(new Error("ROUTE_ALREADY_EXISTS"), { code: "ROUTE_ALREADY_EXISTS", proposedRoute });
+            }
+        }
+
+        return tx.link.update({
+            where: { id },
+            data,
+        });
     });
 
     return NextResponse.json({ success: true, link: updatedLink });
   } catch (err: unknown) {
+    const error = err as { code?: string; proposedRoute?: string };
+    
+    if (error?.code === "ROUTE_ALREADY_EXISTS") {
+        return NextResponse.json(
+            { error: `The route '/${error.proposedRoute}' is already in use.` },
+            { status: 409 }
+        );
+    }
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
       const labelForErrorMessage = (typeof label === "string" ? label.trim() : link.label) || "custom link";
       return NextResponse.json(

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: Request) {
     const body = await req.json();
     const rawUrl = body?.url?.trim();
     const customLabel = body?.label?.trim();
+    const customAlias = body?.alias?.trim();
     const rawExplicitPlatform = body?.platform?.trim();
     const explicitPlatform = rawExplicitPlatform && Object.keys(PLATFORM_ICONS).includes(rawExplicitPlatform) 
         ? rawExplicitPlatform 
@@ -123,6 +124,24 @@ export async function POST(req: Request) {
         );
     }
 
+    const proposedRoute = customAlias || finalPlatform;
+    const existingLink = await prisma.link.findFirst({
+        where: {
+            userId: user.id,
+            OR: [
+                { alias: proposedRoute },
+                { platform: proposedRoute, alias: null }
+            ]
+        }
+    });
+
+    if (existingLink) {
+        return NextResponse.json(
+            { error: `The route '/${proposedRoute}' is already in use. Please provide a unique custom alias.` },
+            { status: 409 }
+        );
+    }
+
     try {
         const link = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
             const maxOrder = await tx.link.aggregate({
@@ -141,6 +160,7 @@ export async function POST(req: Request) {
                 data: {
                     userId: user.id,
                     platform: finalPlatform,
+                    alias: customAlias || null,
                     label: finalLabel,
                     url: finalUrl,
                     position: (maxOrder._max.position ?? 0) + 1,

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -44,7 +44,16 @@ export async function POST(req: Request) {
     const body = await req.json();
     const rawUrl = body?.url?.trim();
     const customLabel = body?.label?.trim();
-    const customAlias = body?.alias?.trim();
+    const rawAlias = body?.alias?.trim();
+    let customAlias = rawAlias ? rawAlias.toLowerCase().replace(/[^a-z0-9-]/g, "") : undefined;
+    
+    if (rawAlias && !customAlias) {
+        return NextResponse.json(
+            { error: "Please enter a valid alphanumeric custom alias" },
+            { status: 400 }
+        );
+    }
+    
     const rawExplicitPlatform = body?.platform?.trim();
     const explicitPlatform = rawExplicitPlatform && Object.keys(PLATFORM_ICONS).includes(rawExplicitPlatform) 
         ? rawExplicitPlatform 
@@ -125,25 +134,23 @@ export async function POST(req: Request) {
     }
 
     const proposedRoute = customAlias || finalPlatform;
-    const existingLink = await prisma.link.findFirst({
-        where: {
-            userId: user.id,
-            OR: [
-                { alias: proposedRoute },
-                { platform: proposedRoute, alias: null }
-            ]
-        }
-    });
-
-    if (existingLink) {
-        return NextResponse.json(
-            { error: `The route '/${proposedRoute}' is already in use. Please provide a unique custom alias.` },
-            { status: 409 }
-        );
-    }
 
     try {
         const link = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+            const existingLink = await tx.link.findFirst({
+                where: {
+                    userId: user.id,
+                    OR: [
+                        { alias: proposedRoute },
+                        { platform: proposedRoute, alias: null }
+                    ]
+                }
+            });
+
+            if (existingLink) {
+                throw Object.assign(new Error("ROUTE_ALREADY_EXISTS"), { code: "ROUTE_ALREADY_EXISTS" });
+            }
+
             const maxOrder = await tx.link.aggregate({
                 where: { userId: user.id },
                 _max: { position: true },
@@ -171,6 +178,13 @@ export async function POST(req: Request) {
         return NextResponse.json({ link });
     } catch (err: unknown) {
         const error = err as { code?: string };
+
+        if (error?.code === "ROUTE_ALREADY_EXISTS") {
+            return NextResponse.json(
+                { error: `The route '/${proposedRoute}' is already in use. Please provide a unique custom alias.` },
+                { status: 409 }
+            );
+        }
 
         if (error?.code === "LINK_LIMIT_REACHED") {
             return NextResponse.json(

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
     const rawUrl = body?.url?.trim();
     const customLabel = body?.label?.trim();
     const rawAlias = body?.alias?.trim();
-    let customAlias = rawAlias ? rawAlias.toLowerCase().replace(/[^a-z0-9-]/g, "") : undefined;
+    const customAlias = rawAlias ? rawAlias.toLowerCase().replace(/[^a-z0-9-]/g, "") : undefined;
     
     if (rawAlias && !customAlias) {
         return NextResponse.json(
@@ -173,6 +173,8 @@ export async function POST(req: Request) {
                     position: (maxOrder._max.position ?? 0) + 1,
                 },
             });
+        }, {
+            isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
         });
 
         return NextResponse.json({ link });

--- a/app/dashboard/AddLinkBox.tsx
+++ b/app/dashboard/AddLinkBox.tsx
@@ -35,12 +35,15 @@ export default function AddLinkBox({
 }) {
     const [url, setUrl] = useState("");
     const [label, setLabel] = useState("");
+    const [alias, setAlias] = useState("");
     const [platform, setPlatform] = useState("");
     const [loading, setLoading] = useState(false);
+    const [showAdvanced, setShowAdvanced] = useState(false);
 
     function handleCancel() {
         setUrl("");
         setLabel("");
+        setAlias("");
         setPlatform("");
         onCancel?.();
     }
@@ -77,6 +80,7 @@ export default function AddLinkBox({
                 body: JSON.stringify({
                     url,
                     label: finalLabel,
+                    alias,
                     platform,
                 }),
             });
@@ -92,7 +96,9 @@ export default function AddLinkBox({
 
             setUrl("");
             setLabel("");
+            setAlias("");
             setPlatform("");
+            setShowAdvanced(false);
         } catch (err: unknown) {
             const errorMessage = err instanceof Error ? err.message : "Failed to add link";
             toast.error(errorMessage);
@@ -133,6 +139,28 @@ export default function AddLinkBox({
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
             />
+
+            <div>
+                <button
+                    type="button"
+                    onClick={() => setShowAdvanced(!showAdvanced)}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors underline"
+                >
+                    {showAdvanced ? "Hide Advanced Options" : "Show Advanced Options (Custom URL Alias)"}
+                </button>
+                {showAdvanced && (
+                    <div className="mt-3">
+                        <Input
+                            placeholder="Custom Alias (e.g. github-work)"
+                            value={alias}
+                            onChange={(e) => setAlias(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))}
+                        />
+                        <p className="text-xs text-muted-foreground mt-1">
+                            Overrides the default route. Your link will be accessible at: /username/{alias || platform || "[alias]"}
+                        </p>
+                    </div>
+                )}
+            </div>
 
             <div className="flex gap-2">
                 <Button onClick={handleCancel} variant="outline" disabled={loading} className="flex-1">

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -75,7 +75,7 @@ export function LinkItem({
 
     function copy() {
         navigator.clipboard.writeText(
-            `linkid.qzz.io/${username}/${link.platform}`
+            `linkid.qzz.io/${username}/${link.alias || link.platform}`
         );
         setCopied(true);
         toast.success("Copied");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model UserAlias {
 model Link {
   id        String   @id @default(uuid())
   platform  String
+  alias     String?
   label     String
   url       String
   position  Int      @default(0)
@@ -60,8 +61,6 @@ model Link {
   dailyAnalytics DailyLinkAnalytics[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-
-  @@unique([userId, platform])
   @@index([userId])
   @@index([platform])
 }


### PR DESCRIPTION
## Resolves #431

### ✨ Feature Description
This PR allows users to define a custom path alias for a link while retaining the platform's auto-detected icon. This solves the issue of users wanting to add multiple accounts for the same platform (e.g., a personal GitHub and an enterprise GitHub) and differentiating them with custom URLs (e.g., `/github-work` and `/github-personal`).

### 💡 Proposed Changes
- **Prisma Schema Update**: Added an optional `alias` field to the `Link` model and removed the composite uniqueness constraint (`@@unique([userId, platform])`) to permit multiple links to the same platform.
- **Link Creation API**: Updated the `POST /api/links` and `PUT /api/links/[id]` logic to extract the `alias` and enforce application-level validation to guarantee route uniqueness (derived from `alias` or `platform`).
- **Dashboard UI**: Added an "Advanced Options" toggle in `AddLinkBox.tsx` that exposes a custom URL alias input for users when creating new links. 
- **Dynamic Routing**: Updated the dynamic routing in `app/[username]/[platform]/page.tsx` to search the database using an `OR` condition for a matching `alias` first, falling back to the standard `platform` detection if no alias is found. We also mapped downstream native app intent routing (for Android deep linking) to use the original `link.platform` rather than the aliased URL param.
- **Profile Display**: Refactored `ProfileLinkItem.tsx` and the dashboard link `copy` button to construct paths using `link.alias || link.platform`, ensuring the external routing respects the new custom path while correctly rendering the platform's original icon.

### 🎯 Acceptance Criteria Verified
- [x] Users can successfully save two links for the same platform if they provide a custom alias for at least one.
- [x] The custom alias successfully redirects to the target URL.
- [x] The public profile still correctly identifies the base platform (e.g., it still renders the GitHub icon even if the alias is `github-work`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional custom URL aliases via advanced link settings when creating a new link.
  * Profile and redirect links now use the configured alias when available.
  * Redirect interstitials resolve and display the actual app platform.

* **Bug Fixes**
  * Prevented route conflicts by blocking duplicate aliases/platform routes for the same user during link creation and updates.
  * Improved copied link URLs to include the custom alias when configured.
  * Updated redirect resolution to respect stored alias/platform values for consistent routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->