### PR TITLE
Feat/dynamic og images

### DIFF
--- a/app/[username]/opengraph-image.tsx
+++ b/app/[username]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { resolveUserByUsername } from '@/lib/userLookup';
+import { PLATFORM_ICONS } from '@/lib/platformIcons';
 
 export const alt = 'LinkID Profile';
 export const size = {
@@ -147,6 +148,8 @@ export default async function Image({ params }: { params: Promise<{ username: st
           >
             {[0, 1, 2].map((index) => {
               const link = links[index];
+              const Icon = link ? PLATFORM_ICONS[link.platform] : null;
+              
               return (
                 <div
                   key={index}
@@ -173,7 +176,9 @@ export default async function Image({ params }: { params: Promise<{ username: st
                       marginRight: 24,
                     }}
                   >
-                    {link && (
+                    {Icon ? (
+                      <Icon style={{ width: 24, height: 24, color: '#fff' }} />
+                    ) : link && (
                       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
                         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
@@ -210,3 +215,4 @@ export default async function Image({ params }: { params: Promise<{ username: st
     { ...size }
   );
 }
+


### PR DESCRIPTION
## 🚀 Description

**Resolves: #428**

This PR enhances the dynamic OpenGraph (OG) image generation for user profiles by replacing the generic SVG placeholders with the user's actual platform icons. 

Previously, when a LinkID profile was shared on social media, the OG image correctly fetched the user's details but rendered a hardcoded placeholder icon for all their links. Now, the preview intelligently maps the link's platform to its corresponding icon component (via `PLATFORM_ICONS`), creating a truly personalized and professional link preview that aligns with the dark/clean aesthetic of the LinkID brand.

### ✨ What changed?
- Modified `app/[username]/opengraph-image.tsx` to conditionally render actual platform icons instead of the static fallback SVG.
- Imported and mapped Satori-compatible icons using the existing `lib/platformIcons.ts` configuration.
- Maintained the existing bento-grid layout, gradient backgrounds, and responsive sizing.

### 📸 Expected Behavior
When sharing `linkid.qzz.io/username` on platforms like Discord or Twitter, the unfurled image now prominently displays the exact icons of the user's top 3 platforms (e.g., GitHub, LinkedIn, X) alongside their username and avatar.

### ✅ Checklist
- [x] Tested the local Next.js build (`next build`) to ensure the Edge runtime correctly compiles the new imports.
- [x] Code is synced and up to date with the upstream `main` branch.
- [x] Retained the LinkID aesthetic and typography.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Social preview images now display platform-specific icons for supported links.
  * Generic link icons remain available when no platform-specific icon is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->