### PR TITLE
fix: add missing await on checkRateLimit call

### DIFF
--- a/app/api/jobs/enqueue/route.ts
+++ b/app/api/jobs/enqueue/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const allowed = checkRateLimit(
+    const allowed = await checkRateLimit(
         `job-enqueue:${session.user.email}`,
         ENQUEUE_LIMIT,
         ENQUEUE_WINDOW_MS


### PR DESCRIPTION
Fixes #462
Description
The checkRateLimit function is async and returns Promise<boolean>, but at app/api/jobs/enqueue/route.ts:17 it was called without await. The allowed variable received a pending Promise object instead of the resolved boolean. Since all objects are truthy in JavaScript, the if (!allowed) check on line 23 was always false, and the rate limit branch was never entered. Users could fire unlimited rapid requests to the job enqueue endpoint without any throttling.
Type of Change
- Feature
- Bug Fix
- UI/UX Improvement
- Performance Optimization
- Security Enhancement
- Refactoring
- Documentation
- Testing
- Infrastructure
- Integration
Changes Implemented
Added await before checkRateLimit(...) call on line 17 so the resolved boolean is correctly assigned to allowed.
Technical Details
Frontend
N/A
Backend
- app/api/jobs/enqueue/route.ts line 17: const allowed = await checkRateLimit(...)
Database
N/A
API
N/A
Infrastructure
N/A
Screenshots
N/A
Testing
Unit Tests
- N/A
Integration Tests
- N/A
E2E Tests
- N/A
Manual Testing
- Verified rate limiting now correctly blocks requests after limit is exceeded
Security Review
Rate limiting is now functional, preventing abuse of the job enqueue endpoint.
Accessibility Review
N/A
Performance Impact
None
Breaking Changes
- No Breaking Changes
- Breaking Changes Documented
Deployment Notes
None
Rollback Plan
Revert the await addition on line 17 of app/api/jobs/enqueue/route.ts.
Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules