### PR TITLE
 feat: add scheduled and expiring links functionality

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -103,6 +103,13 @@ export default async function PublicProfile({
     bgStyle.backgroundImage = "linear-gradient(180deg, #09090b 0%, #1e1b4b 100%)";
   }
 
+  const now = new Date();
+  const activeLinks = (user.links || []).filter((link) => {
+    if (link.startDate && new Date(link.startDate) > now) return false;
+    if (link.endDate && new Date(link.endDate) < now) return false;
+    return true;
+  });
+
   return (
     <main className="min-h-screen px-4 py-16" style={bgStyle}>
       <div className="mx-auto max-w-md">
@@ -114,7 +121,7 @@ export default async function PublicProfile({
               resolved.canonicalUsername,
             bio: user.bio,
             image: user.image,
-            links: user.links || [],
+            links: activeLinks,
             resumeUrl: publicUserData?.resumeUrl ?? null,
           }}
           username={resolved.canonicalUsername}

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -8,6 +8,8 @@ export type Link = {
     position: number;
     clicks: number;
     isPublic: boolean;
+    startDate?: Date | null;
+    endDate?: Date | null;
     updatedAt?: Date;
     userId: string;
 }

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -121,11 +121,34 @@ export async function PUT(
   }
 
   if (startDate !== undefined) {
-    data.startDate = startDate ? new Date(startDate) : null;
+    if (startDate) {
+      const d = new Date(startDate);
+      if (isNaN(d.getTime())) {
+        return NextResponse.json({ error: "Invalid start date" }, { status: 400 });
+      }
+      data.startDate = d;
+    } else {
+      data.startDate = null;
+    }
   }
 
   if (endDate !== undefined) {
-    data.endDate = endDate ? new Date(endDate) : null;
+    if (endDate) {
+      const d = new Date(endDate);
+      if (isNaN(d.getTime())) {
+        return NextResponse.json({ error: "Invalid end date" }, { status: 400 });
+      }
+      data.endDate = d;
+    } else {
+      data.endDate = null;
+    }
+  }
+
+  const finalStartDate = data.startDate !== undefined ? data.startDate : link.startDate;
+  const finalEndDate = data.endDate !== undefined ? data.endDate : link.endDate;
+
+  if (finalStartDate && finalEndDate && finalStartDate > finalEndDate) {
+    return NextResponse.json({ error: "Start date cannot be later than end date" }, { status: 400 });
   }
 
   if (Object.keys(data).length === 0) {

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -42,6 +42,8 @@ export async function PUT(
   const isPublic = body?.isPublic;
   const label = body?.label;
   const platform = body?.platform;
+  const startDate = body?.startDate;
+  const endDate = body?.endDate;
 
   const rawExplicitPlatform = typeof platform === "string" ? platform.trim() : null;
   const explicitPlatform = rawExplicitPlatform && Object.keys(PLATFORM_ICONS).includes(rawExplicitPlatform)
@@ -57,7 +59,7 @@ export async function PUT(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const data: { url?: string; isPublic?: boolean; label?: string; platform?: string } = {};
+  const data: { url?: string; isPublic?: boolean; label?: string; platform?: string; startDate?: Date | null; endDate?: Date | null } = {};
 
   const activeLabel = typeof label === "string" ? label.trim() : link.label;
 
@@ -116,6 +118,14 @@ export async function PUT(
 
   if (typeof isPublic === "boolean") {
     data.isPublic = isPublic;
+  }
+
+  if (startDate !== undefined) {
+    data.startDate = startDate ? new Date(startDate) : null;
+  }
+
+  if (endDate !== undefined) {
+    data.endDate = endDate ? new Date(endDate) : null;
   }
 
   if (Object.keys(data).length === 0) {

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -25,7 +25,7 @@ export default function DashboardClient({
         setShowAdd(false);
     }
 
-    async function updateLink(id: string, url: string, label?: string, platform?: string): Promise<boolean> {
+    async function updateLink(id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null): Promise<boolean> {
         const csrfToken = await getCsrfToken();
 
         try {
@@ -35,7 +35,7 @@ export default function DashboardClient({
                     "Content-Type": "application/json",
                     "x-csrf-token": csrfToken,
                 },
-                body: JSON.stringify({ url, label, platform }),
+                body: JSON.stringify({ url, label, platform, startDate, endDate }),
             });
 
             if (!response.ok) {

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -61,6 +61,7 @@ export function LinkItem({
     const toDatetimeLocal = (date?: Date | string | null) => {
         if (!date) return "";
         const d = new Date(date);
+        if (isNaN(d.getTime())) return "";
         d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
         return d.toISOString().slice(0, 16);
     };
@@ -104,6 +105,10 @@ export function LinkItem({
         const trimmedLabel = label.trim();
         if (!trimmedLabel) {
             return toast.error("Please enter a display name for this link");
+        }
+
+        if (startDate && endDate && startDate > endDate) {
+            return toast.error("Start date cannot be later than end date");
         }
 
         const success = await onUpdate(link.id, url, trimmedLabel, platform, startDate, endDate);

--- a/app/dashboard/LinkItem.tsx
+++ b/app/dashboard/LinkItem.tsx
@@ -43,7 +43,7 @@ export function LinkItem({
     dragAttributes?: DraggableAttributes;
     link: ProfileLink;
     username: string;
-    onUpdate: (id: string, url: string, label?: string, platform?: string) => Promise<boolean>;
+    onUpdate: (id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null) => Promise<boolean>;
     onToggleVisibility: (id: string, isPublic: boolean) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
 }) {
@@ -53,8 +53,17 @@ export function LinkItem({
     const isStandardPlatform = Object.keys(PLATFORM_ICONS).includes(link.platform);
     const initialPlatform = isStandardPlatform ? link.platform : PLATFORMS.WEBSITE;
     const [platform, setPlatform] = useState(initialPlatform);
+    const [startDate, setStartDate] = useState<Date | null>(link.startDate ? new Date(link.startDate) : null);
+    const [endDate, setEndDate] = useState<Date | null>(link.endDate ? new Date(link.endDate) : null);
     const [copied, setCopied] = useState(false);
     const Icon = PLATFORM_ICONS[editing ? platform : link.platform] ?? Globe;
+
+    const toDatetimeLocal = (date?: Date | string | null) => {
+        if (!date) return "";
+        const d = new Date(date);
+        d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+        return d.toISOString().slice(0, 16);
+    };
 
     const handlePlatformChange = (newPlatform: string) => {
         setPlatform(newPlatform);
@@ -97,7 +106,7 @@ export function LinkItem({
             return toast.error("Please enter a display name for this link");
         }
 
-        const success = await onUpdate(link.id, url, trimmedLabel, platform);
+        const success = await onUpdate(link.id, url, trimmedLabel, platform, startDate, endDate);
         if (success) {
             setEditing(false);
         }
@@ -173,6 +182,8 @@ export function LinkItem({
                                 setUrl(link.url);
                                 setLabel(link.label || "");
                                 setPlatform(initialPlatform);
+                                setStartDate(link.startDate ? new Date(link.startDate) : null);
+                                setEndDate(link.endDate ? new Date(link.endDate) : null);
                             }
                             setEditing((v) => !v);
                         }}
@@ -229,6 +240,35 @@ export function LinkItem({
                             className="flex-1 px-2 py-4 text-sm"
                         />
                     </div>
+
+                    <details className="group border rounded-md p-3 [&_summary::-webkit-details-marker]:hidden">
+                        <summary className="flex cursor-pointer items-center justify-between font-medium text-sm text-muted-foreground">
+                            Advanced Settings
+                            <span className="transition group-open:rotate-180">
+                                <svg fill="none" height="24" shapeRendering="geometricPrecision" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" viewBox="0 0 24 24" width="24"><path d="M6 9l6 6 6-6"></path></svg>
+                            </span>
+                        </summary>
+                        <div className="mt-3 flex flex-col gap-3 sm:flex-row text-sm">
+                            <div className="flex-1">
+                                <label className="block text-xs text-muted-foreground mb-1">Visible From</label>
+                                <Input
+                                    type="datetime-local"
+                                    value={toDatetimeLocal(startDate)}
+                                    onChange={(e) => setStartDate(e.target.value ? new Date(e.target.value) : null)}
+                                    className="w-full text-sm"
+                                />
+                            </div>
+                            <div className="flex-1">
+                                <label className="block text-xs text-muted-foreground mb-1">Visible Until</label>
+                                <Input
+                                    type="datetime-local"
+                                    value={toDatetimeLocal(endDate)}
+                                    onChange={(e) => setEndDate(e.target.value ? new Date(e.target.value) : null)}
+                                    className="w-full text-sm"
+                                />
+                            </div>
+                        </div>
+                    </details>
 
                     <div className="flex gap-2 justify-end">
                         <Button size="icon" onClick={save} aria-label="Save changes">

--- a/app/dashboard/LinksSection.tsx
+++ b/app/dashboard/LinksSection.tsx
@@ -28,7 +28,7 @@ type LinksSectionProps = {
     setShowAdd: React.Dispatch<React.SetStateAction<boolean>>;
     onExport: () => void;
     onAdd: (link: ProfileLink) => void | Promise<void>;
-    onUpdate: (id: string, url: string, label?: string, platform?: string) => Promise<boolean>;
+    onUpdate: (id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null) => Promise<boolean>;
     onToggleVisibility: (id: string, isPublic: boolean) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
     onReorder: (links: ProfileLink[]) => void;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,8 @@ model Link {
   position  Int      @default(0)
   clicks    Int      @default(0)
   isPublic  Boolean  @default(true)
+  startDate DateTime?
+  endDate   DateTime?
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   clickEvents ClickEvent[]


### PR DESCRIPTION
### 📝 Description

This PR implements the requested "Scheduled / Expiring Links" functionality, closing out **Issue #460**. 

**✨ Feature Overview**
Users can now set a custom schedule (start date and/or expiration date) for their links from the dashboard. Links will automatically become visible on their public profile when the timeframe starts, and will automatically disappear when the event/timeframe ends.

**🤔 Problem It Solves**
Content creators or professionals who run limited-time promotions (e.g., webinar registrations, 48-hour discount codes, or hackathons) can now set up their links in advance. This automates link visibility and prevents public profiles from being cluttered with expired or dead links.

### 🛠️ Changes Proposed
- **Database Schema (`prisma/schema.prisma`):** Added optional `startDate` and `endDate` (DateTime) fields to the `Link` model.
- **API route (`app/api/links/[id]/route.ts`):** Modified the PUT route to accept, parse, and securely update the `startDate` and `endDate` fields in the database.
- **Link Editor UI (`app/dashboard/LinkItem.tsx`):** Added an expandable "Advanced Settings" accordion containing two `datetime-local` pickers ("Visible From" and "Visible Until"), allowing users to easily select scheduling bounds or clear them to make the link permanent again.
- **Public Profile Query (`app/[username]/page.tsx`):** Modified the server-side logic to filter `user.links`, completely excluding any links that haven't started yet or have already expired before sending them to the frontend `ProfileCard`.
- **Merge Consistency:** Addressed upstream merge conflicts smoothly, ensuring that this new scheduling logic successfully lives side-by-side with the newly introduced Custom Profile Themes feature.

### 🎯 Acceptance Criteria Met
- [x] Users can set an expiration date for a link in the dashboard.
- [x] The Next.js server-side query correctly excludes expired links before rendering the public profile.
- [x] Users can easily clear the dates to make the link permanent again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional visibility scheduling for links with “Visible From” and “Visible Until” date/time settings.
  - Dashboard editing now supports saving these visibility windows for each link.
  - Added new start/end date fields to link records for controlled public display timing.
- **Bug Fixes**
  - Public profiles now automatically hide links that are not yet active or have expired based on the current time.
  - Improved validation when updating visibility dates to prevent invalid or conflicting ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->