### PR TITLE
feat: add dynamic sitemap.xml and robots.txt for public profile SEO

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = (process.env.NEXT_PUBLIC_BASE_URL || "https://linkid.qzz.io").replace(/\/$/, "");
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: ["/"],
+      disallow: [
+        "/dashboard",
+        "/dashboard/",
+        "/api",
+        "/api/",
+        "/login",
+        "/register",
+        "/profile",
+        "/account-deleted",
+      ],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { getPublishedUsernames } from "@/lib/userLookup";
+
+const BASE_URL = (process.env.NEXT_PUBLIC_BASE_URL || "https://linkid.qzz.io").replace(/\/$/, "");
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const users = await getPublishedUsernames();
+
+  const profileEntries: MetadataRoute.Sitemap = users.map((user) => ({
+    url: `${BASE_URL}/${user.username}`,
+    lastModified: user.createdAt,
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    ...profileEntries,
+  ];
+}

--- a/lib/userLookup.ts
+++ b/lib/userLookup.ts
@@ -58,3 +58,21 @@ export const getPublicUserData = unstable_cache(
     { revalidate: 60, tags: ["public-profile"] }
 );
 
+/**
+ * Get all users with a published (public) profile, for sitemap generation.
+ * A profile is considered "published" once the user has claimed a username.
+ */
+export const getPublishedUsernames = unstable_cache(
+    async () => {
+        const users = await prisma.user.findMany({
+            where: { username: { not: null } },
+            select: { username: true, createdAt: true },
+        });
+
+        return users.filter(
+            (u): u is { username: string; createdAt: Date } => u.username !== null
+        );
+    },
+    ["getPublishedUsernames"],
+    { revalidate: 3600, tags: ["public-profile"] }
+);


### PR DESCRIPTION
Closes #461

## Summary

Adds a dynamically generated `sitemap.xml` and `robots.txt` so that public LinkID profiles are discoverable and correctly indexed by search engines, using Next.js's native App Router metadata file conventions (`MetadataRoute.Sitemap` / `MetadataRoute.Robots`), no extra packages
required.

## Changes

### `app/sitemap.ts` (new)
- Generates `/sitemap.xml` at request time.
- Includes the homepage plus one `<url>` entry per **published** profile.
- A profile is considered "published" once the user has claimed a `username` (the schema has no separate boolean flag for this, so `username IS NOT NULL` is used as the publish condition).
- Each profile entry uses the user's `createdAt` as `lastModified`, `changeFrequency: "weekly"`, and `priority: 0.8`. The homepage entry uses `changeFrequency: "daily"`, `priority: 1`.

### `app/robots.ts` (new)
- Generates `/robots.txt` at request time.
- Allows `/` (covers the homepage and all public `/<username>` profiles).
- Disallows private/internal routes: `/dashboard`, `/api`, `/login`, `/register`, `/profile`, `/account-deleted`.
- Points to `${NEXT_PUBLIC_BASE_URL}/sitemap.xml` via the `sitemap` field.

### `lib/userLookup.ts` (modified)
- Added `getPublishedUsernames()`, following the same `unstable_cache` pattern already used by `resolveUserByUsername` / `getPublicUserData` in this file (1hr revalidate, tagged `public-profile`).
- Fetches `{ username, createdAt }` for all users with a non-null username, for use by `app/sitemap.ts`.

## Base URL

Both files read `process.env.NEXT_PUBLIC_BASE_URL` (already defined in `.env.example`) and fall back to `https://linkid.qzz.io` if unset.

## Testing

Tested locally with Postgres via Docker:
- `/robots.txt` renders correctly with the expected allow/disallow rules and a `Sitemap:` line.
- `/sitemap.xml` renders valid XML with just the homepage entry on an empty database.

<img width="1917" height="958" alt="Screenshot 2026-07-20 191845" src="https://github.com/user-attachments/assets/abcadea9-1b9d-451d-b872-8b788fb1cfac" />

---

<img width="1917" height="955" alt="Screenshot 2026-07-20 193532" src="https://github.com/user-attachments/assets/3f24ea80-97e6-4c45-8c62-c03b84f1444d" />

---

## Notes for reviewers

- No Prisma schema/migration changes — "published" is derived from the existing `username` field rather than a new column, per the issue's note that a migration likely isn't needed.
- Open question: if a stricter definition of "published" is preferred (e.g. requiring at least one visible link), that's a small change
  confined to `getPublishedUsernames()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sitemap generation for the homepage and published profile pages.
  * Added search engine crawling rules that allow public content while excluding private and application-only routes.
  * Sitemap entries include update dates and indexing priorities for improved discoverability.
  * Sitemap data refreshes periodically to reflect newly published profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->