### PR TITLE
fix(auth): refactor email verification logic to lib

### DIFF
--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
+import { verifyUserEmail } from "@/lib/verifyEmail";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
@@ -9,28 +9,11 @@ export async function GET(req: Request) {
         return NextResponse.redirect(new URL("/login?error=missing-token", req.url));
     }
 
-    const verificationToken = await prisma.verificationToken.findUnique({
-        where: { token },
-    });
+    const result = await verifyUserEmail(token);
 
-    if (!verificationToken) {
-        return NextResponse.redirect(new URL("/login?error=invalid-token", req.url));
+    if (result.error) {
+        return NextResponse.redirect(new URL(`/login?error=${result.error}`, req.url));
     }
-
-    if (verificationToken.expires < new Date()) {
-        // Clean up expired token
-        await prisma.verificationToken.delete({ where: { token } });
-        return NextResponse.redirect(new URL("/login?error=token-expired", req.url));
-    }
-
-    // Mark email as verified and clean up token atomically
-    await prisma.$transaction([
-        prisma.user.updateMany({
-            where: { email: verificationToken.identifier },
-            data: { emailVerified: new Date() },
-        }),
-        prisma.verificationToken.delete({ where: { token } }),
-    ]);
 
     return NextResponse.redirect(new URL("/login?verified=true", req.url));
 }

--- a/lib/verifyEmail.ts
+++ b/lib/verifyEmail.ts
@@ -1,0 +1,28 @@
+import prisma from "@/lib/prisma";
+
+export async function verifyUserEmail(token: string) {
+    const verificationToken = await prisma.verificationToken.findUnique({
+        where: { token },
+    });
+
+    if (!verificationToken) {
+        return { error: "invalid-token" };
+    }
+
+    if (verificationToken.expires < new Date()) {
+        // Clean up expired token
+        await prisma.verificationToken.delete({ where: { token } });
+        return { error: "token-expired" };
+    }
+
+    // Mark email as verified and clean up token atomically
+    await prisma.$transaction([
+        prisma.user.updateMany({
+            where: { email: verificationToken.identifier },
+            data: { emailVerified: new Date() },
+        }),
+        prisma.verificationToken.delete({ where: { token } }),
+    ]);
+
+    return { success: true };
+}


### PR DESCRIPTION
## What does this PR do?
Extracts the email verification business logic from `app/api/auth/verify-email/route.ts` into a utility function `verifyUserEmail` inside `lib/verifyEmail.ts`. This ensures API routes are kept thin and strictly follow the project's convention of keeping business logic in the `lib/` directory.

## Related Issue
Closes #483

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor

## How to Test
1. Go to `/register` and create a new account using an email address and password.
2. Check your email inbox for the verification email.
3. Click on the verification link inside the email.
4. Verify that you are successfully redirected to `/login?verified=true` and that your user account has `emailVerified` set in the database.

## Screenshots (if UI change)
N/A (API Logic Refactor)

## Checklist
- [x] Code follows project conventions
- [x] Self-reviewed the changes
- [x] No console.log left behind
- [x] No new TypeScript errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email verification handling for invalid and expired verification links.
  * Expired verification tokens are cleaned up automatically.
  * Successful verification continues to redirect users to login with confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->