### PR TITLE
fix(navbar): prevent mobile dropdown from overlapping hero text

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -217,7 +217,7 @@ export function Navbar() {
                     className={`mt-2 overflow-hidden rounded-3xl border transition-all duration-300 ease-in-out md:hidden ${mobileOpen
                         ? "max-h-80 border-violet-300/20 opacity-100 shadow-lg shadow-violet-950/20 dark:border-violet-500/20 dark:shadow-violet-950/40"
                         : "max-h-0 border-transparent opacity-0"
-                        } bg-white/15 backdrop-blur-3xl dark:bg-violet-950/60`}
+                        } bg-white/95 backdrop-blur-3xl dark:bg-violet-950/95`}
                 >
                     <div className="px-3 pb-4 pt-3">
                         <nav className="mb-3 flex flex-col gap-1">


### PR DESCRIPTION

Closes #490

## What does this PR do?
Fixes an issue where the mobile navbar dropdown menu overlaps with the hero section content by increasing the background opacity of the dropdown container. This makes the text clearly visible and readable.

## Related Issue
Closes #490

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## How to Test
1. Go to the home page on a mobile device or shrink the browser window to mobile width.
2. Click on the hamburger menu icon in the navbar.
3. Verify that the expanded menu has a highly opaque background and the hero section content is no longer overlapping the menu links.

## Screenshots (if UI change)
<!-- Before / After screenshots -->

## Checklist
- [x] Code follows project conventions
- [x] Self-reviewed the changes
- [x] No console.log left behind
- [x] No new TypeScript errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the mobile navigation dropdown’s readability with a more opaque background in both light and dark modes.
  - Preserved existing dropdown behavior and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->