### PR TITLE
fix: add rel attribute to LinkIdCard external link

### DIFF
--- a/app/dashboard/LinkIdCard.tsx
+++ b/app/dashboard/LinkIdCard.tsx
@@ -53,7 +53,7 @@ export function LinkIdCard({ username, qrCode }: { username: string; qrCode?: Re
           asChild
           className="w-full sm:w-auto justify-center gap-2"
         >
-          <a href={`/${username}`} target="_blank">
+          <a href={`/${username}`} target="_blank" rel="noopener noreferrer">
             <ExternalLink className="h-4 w-4" />
             Open
           </a>


### PR DESCRIPTION
## Description

Audited all `target="_blank"` links referenced in issue #505.

Most locations were already using `rel="noopener noreferrer"` correctly. One missing occurrence was identified and fixed in:

- `app/dashboard/LinkIdCard.tsx`

This change ensures consistency across external links and helps prevent reverse tabnabbing attacks.

Closes #505 

## Testing

- Verified all audited links continue to function normally.
- Confirmed the missing `rel="noopener noreferrer"` attribute was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced safety when opening links in a new browser tab by preventing the opened page from accessing the original window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->