### PR TITLE
feat: Add Mail/Newsletter Subscribe Block

### DIFF
--- a/app/[username]/NewsletterSubscribeBlock.tsx
+++ b/app/[username]/NewsletterSubscribeBlock.tsx
@@ -28,8 +28,9 @@ export function NewsletterSubscribeBlock({ username }: { username: string }) {
 
             toast.success("Subscribed successfully!");
             setEmail("");
-        } catch (error: any) {
-            toast.error(error.message || "Failed to subscribe");
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : "Failed to subscribe";
+            toast.error(message);
         } finally {
             setLoading(false);
         }

--- a/app/[username]/NewsletterSubscribeBlock.tsx
+++ b/app/[username]/NewsletterSubscribeBlock.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+export function NewsletterSubscribeBlock({ username }: { username: string }) {
+    const [email, setEmail] = useState("");
+    const [loading, setLoading] = useState(false);
+
+    async function handleSubscribe(e: React.FormEvent) {
+        e.preventDefault();
+        if (!email) return;
+
+        setLoading(true);
+        try {
+            const res = await fetch("/api/subscribe", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ email, username }),
+            });
+
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.error || "Failed to subscribe");
+            }
+
+            toast.success("Subscribed successfully!");
+            setEmail("");
+        } catch (error: any) {
+            toast.error(error.message || "Failed to subscribe");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div className="w-full bg-white/5 backdrop-blur-sm border border-white/10 p-4 rounded-xl shadow-sm my-4">
+            <div className="text-center mb-3">
+                <h3 className="font-semibold">Subscribe to my Newsletter</h3>
+                <p className="text-xs opacity-80 mt-1">Get the latest updates right in your inbox.</p>
+            </div>
+            <form onSubmit={handleSubscribe} className="flex gap-2">
+                <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="Enter your email"
+                    required
+                    className="flex-1 bg-background/50 border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                />
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className="bg-primary text-primary-foreground px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                >
+                    {loading ? "..." : "Subscribe"}
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -3,6 +3,7 @@ import { ProfileHeader } from "./ProfileHeader";
 import { ProfileLinks } from "./ProfileLinks";
 import { ProfileCTA } from "./ProfileCTA";
 import { ProfileCardProps } from "./types/type";
+import { NewsletterSubscribeBlock } from "./NewsletterSubscribeBlock";
 
 export function ProfileCard(props: ProfileCardProps) {
     const { user, username, showCTA, isOwner, themeType } = props;
@@ -25,6 +26,10 @@ export function ProfileCard(props: ProfileCardProps) {
             </CardHeader>
 
             <CardContent className="space-y-3">
+                {user.enableEmailCapture && (
+                    <NewsletterSubscribeBlock username={username} />
+                )}
+
                 <ProfileLinks
                     links={user.links ?? []}
                     username={username}

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -123,6 +123,7 @@ export default async function PublicProfile({
             image: user.image,
             links: activeLinks,
             resumeUrl: publicUserData?.resumeUrl ?? null,
+            enableEmailCapture: user.enableEmailCapture,
           }}
           username={resolved.canonicalUsername}
           showCTA={!session}

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -27,6 +27,7 @@ export type User = {
         image: string | null;
         links?: Link[];
         resumeUrl?: string | null;
+        enableEmailCapture?: boolean;
     };
     username: string;
     showCTA: boolean;

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -13,9 +13,13 @@ export async function PUT(req: NextRequest) {
     const body = await req.json();
     const { enableEmailCapture } = body;
 
+    if (typeof enableEmailCapture !== "boolean") {
+      return NextResponse.json({ error: "enableEmailCapture must be a boolean" }, { status: 400 });
+    }
+
     const user = await prisma.user.update({
       where: { id: userId },
-      data: { enableEmailCapture: Boolean(enableEmailCapture) },
+      data: { enableEmailCapture },
     });
 
     return NextResponse.json({ success: true, enableEmailCapture: user.enableEmailCapture }, { status: 200 });

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function PUT(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
+    const body = await req.json();
+    const { enableEmailCapture } = body;
+
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { enableEmailCapture: Boolean(enableEmailCapture) },
+    });
+
+    return NextResponse.json({ success: true, enableEmailCapture: user.enableEmailCapture }, { status: 200 });
+
+  } catch (error) {
+    console.error("Settings update error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { email, username } = body;
+
+    if (!email || !username) {
+      return NextResponse.json({ error: "Email and username are required" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { username },
+      select: { id: true, enableEmailCapture: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    if (!user.enableEmailCapture) {
+      return NextResponse.json({ error: "Email capture is not enabled for this profile" }, { status: 403 });
+    }
+
+    // Upsert or create subscriber
+    await prisma.subscriber.create({
+      data: {
+        email,
+        userId: user.id,
+      },
+    }).catch(err => {
+        // If unique constraint fails, it means already subscribed
+        if (err.code === 'P2002') {
+            return;
+        }
+        throw err;
+    });
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("Subscribe error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -4,10 +4,12 @@ import prisma from "@/lib/prisma";
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { email, username } = body;
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const username = body.username;
 
-    if (!email || !username) {
-      return NextResponse.json({ error: "Email and username are required" }, { status: 400 });
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email || email.length > 255 || !emailRegex.test(email) || !username) {
+      return NextResponse.json({ error: "A valid email and username are required" }, { status: 400 });
     }
 
     const user = await prisma.user.findUnique({

--- a/app/api/subscribers/export/route.ts
+++ b/app/api/subscribers/export/route.ts
@@ -17,9 +17,16 @@ export async function GET(req: NextRequest) {
             orderBy: { createdAt: "desc" },
         });
 
+        const formatCsvField = (field: string) => {
+            const str = String(field);
+            const needsPrefix = /^[=+\-@]/.test(str);
+            const prefixed = needsPrefix ? `'${str}` : str;
+            return `"${prefixed.replace(/"/g, '""')}"`;
+        };
+
         const csvRows = ["id,email,createdAt"];
         for (const sub of subscribers) {
-            csvRows.push(`${sub.id},${sub.email},${sub.createdAt.toISOString()}`);
+            csvRows.push(`${formatCsvField(sub.id)},${formatCsvField(sub.email)},${formatCsvField(sub.createdAt.toISOString())}`);
         }
         
         const csvString = csvRows.join("\n");

--- a/app/api/subscribers/export/route.ts
+++ b/app/api/subscribers/export/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        
+        const userId = session.user.id;
+
+        const subscribers = await prisma.subscriber.findMany({
+            where: { userId },
+            orderBy: { createdAt: "desc" },
+        });
+
+        const csvRows = ["id,email,createdAt"];
+        for (const sub of subscribers) {
+            csvRows.push(`${sub.id},${sub.email},${sub.createdAt.toISOString()}`);
+        }
+        
+        const csvString = csvRows.join("\n");
+
+        return new NextResponse(csvString, {
+            headers: {
+                "Content-Type": "text/csv",
+                "Content-Disposition": 'attachment; filename="subscribers.csv"',
+            },
+        });
+    } catch (error) {
+        console.error("Export subscribers error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -30,10 +30,12 @@ export default function DashboardClient({
     const [activeTab, setActiveTab] = useState<"links" | "appearance">("links");
     const [showAdd, setShowAdd] = useState(false);
     const [isEmailCaptureEnabled, setIsEmailCaptureEnabled] = useState(enableEmailCapture ?? false);
+    const [isPendingEmailCapture, setIsPendingEmailCapture] = useState(false);
 
     async function toggleEmailCapture() {
+        if (isPendingEmailCapture) return;
         const newValue = !isEmailCaptureEnabled;
-        setIsEmailCaptureEnabled(newValue);
+        setIsPendingEmailCapture(true);
         try {
             const csrfToken = await getCsrfToken();
             const response = await fetch('/api/settings', {
@@ -45,10 +47,13 @@ export default function DashboardClient({
                 body: JSON.stringify({ enableEmailCapture: newValue }),
             });
             if (!response.ok) throw new Error();
-            toast.success(newValue ? "Email capture enabled" : "Email capture disabled");
+            const data = await response.json();
+            setIsEmailCaptureEnabled(data.enableEmailCapture);
+            toast.success(data.enableEmailCapture ? "Email capture enabled" : "Email capture disabled");
         } catch {
-            setIsEmailCaptureEnabled(!newValue);
             toast.error("Failed to update email capture settings");
+        } finally {
+            setIsPendingEmailCapture(false);
         }
     }
 
@@ -140,20 +145,20 @@ export default function DashboardClient({
     }
 
     async function exportSubscribersCsv() {
-        const response = await fetch("/api/subscribers/export");
+        try {
+            const response = await fetch("/api/subscribers/export");
+            if (!response.ok) throw new Error();
 
-        if (!response.ok) {
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `linkid-subscribers-${new Date().toISOString().slice(0, 10)}.csv`;
+            a.click();
+            window.URL.revokeObjectURL(url);
+        } catch {
             toast.error("Unable to export subscribers");
-            return;
         }
-
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `linkid-subscribers-${new Date().toISOString().slice(0, 10)}.csv`;
-        a.click();
-        window.URL.revokeObjectURL(url);
     }
 
     async function deleteLink(id: string) {
@@ -218,9 +223,9 @@ export default function DashboardClient({
                                     <h2 className="text-xl font-bold">Email Subscribers</h2>
                                     <p className="text-sm text-muted-foreground">Collect emails directly from your LinkID page.</p>
                                 </div>
-                                <label className="flex items-center cursor-pointer">
+                                <label className={`flex items-center cursor-pointer ${isPendingEmailCapture ? 'opacity-50 pointer-events-none' : ''}`}>
                                     <div className="relative">
-                                        <input type="checkbox" className="sr-only" checked={isEmailCaptureEnabled} onChange={toggleEmailCapture} />
+                                        <input type="checkbox" className="sr-only" checked={isEmailCaptureEnabled} onChange={toggleEmailCapture} disabled={isPendingEmailCapture} />
                                         <div className={`block w-14 h-8 rounded-full ${isEmailCaptureEnabled ? 'bg-primary' : 'bg-muted'}`}></div>
                                         <div className={`dot absolute left-1 top-1 bg-background w-6 h-6 rounded-full transition ${isEmailCaptureEnabled ? 'transform translate-x-6' : ''}`}></div>
                                     </div>
@@ -247,7 +252,7 @@ export default function DashboardClient({
                                                 {subscribers.map(sub => (
                                                     <li key={sub.id} className="p-2 px-4 flex justify-between">
                                                         <span>{sub.email}</span>
-                                                        <span className="text-muted-foreground">{new Date(sub.createdAt).toLocaleDateString()}</span>
+                                                        <span className="text-muted-foreground">{new Date(sub.createdAt).toLocaleDateString("en-US", { timeZone: "UTC" })}</span>
                                                     </li>
                                                 ))}
                                             </ul>

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -15,16 +15,42 @@ export default function DashboardClient({
     initialLinks,
     initialTheme,
     qrCode,
+    enableEmailCapture,
+    subscribers = [],
 }: {
     username: string;
     initialLinks: ProfileLink[];
     initialTheme?: string;
     qrCode?: React.ReactNode;
+    enableEmailCapture?: boolean;
+    subscribers?: { id: string; email: string; createdAt: Date }[];
 }) {
     const [links, setLinks] = useState(initialLinks);
     const [theme, setTheme] = useState(initialTheme || "default");
     const [activeTab, setActiveTab] = useState<"links" | "appearance">("links");
     const [showAdd, setShowAdd] = useState(false);
+    const [isEmailCaptureEnabled, setIsEmailCaptureEnabled] = useState(enableEmailCapture ?? false);
+
+    async function toggleEmailCapture() {
+        const newValue = !isEmailCaptureEnabled;
+        setIsEmailCaptureEnabled(newValue);
+        try {
+            const csrfToken = await getCsrfToken();
+            const response = await fetch('/api/settings', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-csrf-token': csrfToken,
+                },
+                body: JSON.stringify({ enableEmailCapture: newValue }),
+            });
+            if (!response.ok) throw new Error();
+            toast.success(newValue ? "Email capture enabled" : "Email capture disabled");
+        } catch {
+            setIsEmailCaptureEnabled(!newValue);
+            toast.error("Failed to update email capture settings");
+        }
+    }
 
     async function addLink(link: ProfileLink) {
         setLinks((prev) => [...prev, link]);
@@ -113,6 +139,23 @@ export default function DashboardClient({
         window.URL.revokeObjectURL(url);
     }
 
+    async function exportSubscribersCsv() {
+        const response = await fetch("/api/subscribers/export");
+
+        if (!response.ok) {
+            toast.error("Unable to export subscribers");
+            return;
+        }
+
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `linkid-subscribers-${new Date().toISOString().slice(0, 10)}.csv`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    }
+
     async function deleteLink(id: string) {
         if (!confirm("Delete this link?")) return;
 
@@ -168,18 +211,65 @@ export default function DashboardClient({
                 </div>
 
                 {activeTab === 'links' ? (
-                    <LinksSection
-                        username={username}
-                        links={links}
-                        showAdd={showAdd}
-                        setShowAdd={setShowAdd}
-                        onExport={exportCsv}
-                        onAdd={addLink}
-                        onUpdate={updateLink}
-                        onToggleVisibility={updateVisibility}
-                        onDelete={deleteLink}
-                        onReorder={setLinks}
-                    />
+                    <div className="space-y-6">
+                        <section className="bg-card p-6 rounded-xl border shadow-sm">
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <h2 className="text-xl font-bold">Email Subscribers</h2>
+                                    <p className="text-sm text-muted-foreground">Collect emails directly from your LinkID page.</p>
+                                </div>
+                                <label className="flex items-center cursor-pointer">
+                                    <div className="relative">
+                                        <input type="checkbox" className="sr-only" checked={isEmailCaptureEnabled} onChange={toggleEmailCapture} />
+                                        <div className={`block w-14 h-8 rounded-full ${isEmailCaptureEnabled ? 'bg-primary' : 'bg-muted'}`}></div>
+                                        <div className={`dot absolute left-1 top-1 bg-background w-6 h-6 rounded-full transition ${isEmailCaptureEnabled ? 'transform translate-x-6' : ''}`}></div>
+                                    </div>
+                                </label>
+                            </div>
+                            {isEmailCaptureEnabled && (
+                                <div className="mt-4">
+                                    <div className="flex justify-between items-center mb-2">
+                                        <p className="text-sm font-medium">Total Subscribers: {subscribers.length}</p>
+                                        {subscribers.length > 0 && (
+                                            <button 
+                                                onClick={exportSubscribersCsv}
+                                                className="text-xs font-medium px-3 py-1.5 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 transition-colors"
+                                            >
+                                                Export CSV
+                                            </button>
+                                        )}
+                                    </div>
+                                    <div className="max-h-40 overflow-y-auto border rounded-md">
+                                        {subscribers.length === 0 ? (
+                                            <p className="p-4 text-sm text-muted-foreground">No subscribers yet.</p>
+                                        ) : (
+                                            <ul className="divide-y text-sm">
+                                                {subscribers.map(sub => (
+                                                    <li key={sub.id} className="p-2 px-4 flex justify-between">
+                                                        <span>{sub.email}</span>
+                                                        <span className="text-muted-foreground">{new Date(sub.createdAt).toLocaleDateString()}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </section>
+
+                        <LinksSection
+                            username={username}
+                            links={links}
+                            showAdd={showAdd}
+                            setShowAdd={setShowAdd}
+                            onExport={exportCsv}
+                            onAdd={addLink}
+                            onUpdate={updateLink}
+                            onToggleVisibility={updateVisibility}
+                            onDelete={deleteLink}
+                            onReorder={setLinks}
+                        />
+                    </div>
                 ) : (
                     <AppearanceSection 
                         initialTheme={theme} 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,7 +12,10 @@ export default async function DashboardPage() {
 
     const user = await prisma.user.findUnique({
         where: { email: session.user.email },
-        include: { links: { orderBy: [{ position: 'asc' }, { createdAt: 'asc' }] } },
+        include: { 
+            links: { orderBy: [{ position: 'asc' }, { createdAt: 'asc' }] },
+            subscribers: { orderBy: { createdAt: 'desc' } }
+        },
     });
 
     if (!user?.username) return <CreateLinkId />;
@@ -23,6 +26,8 @@ export default async function DashboardPage() {
             initialLinks={user.links}
             initialTheme={user.theme}
             qrCode={<QRCode />} 
+            enableEmailCapture={user.enableEmailCapture}
+            subscribers={user.subscribers}
         />
     );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   themeType           String   @default("solid")
   themeColor          String   @default("slate")
   themeCustom         String?
+  enableEmailCapture  Boolean  @default(false)
 
   links         Link[]
   accounts      Account[]
@@ -34,6 +35,7 @@ model User {
   profileDraft  ProfileDraft?
   profileVersions ProfileVersion[]
   previewTokens ProfilePreviewToken[]
+  subscribers   Subscriber[]
   createdAt     DateTime @default(now())
 
   theme         String   @default("default")
@@ -285,4 +287,15 @@ model InvalidatedSession {
   createdAt DateTime @default(now())
 
   @@map("invalidatedSession")
+}
+
+model Subscriber {
+  id        String   @id @default(uuid())
+  email     String
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  @@unique([email, userId])
+  @@index([userId])
 }


### PR DESCRIPTION
### Description
This PR introduces a new feature that allows content creators to capture visitor emails directly from their LinkID profile, significantly reducing friction compared to redirecting users to external forms like Mailchimp or Substack.

Closes #522 

### 💡 Problem Solved
Currently, users can only add standard links to separate mailing list forms. This inline email input box sits prominently on the user's LinkID profile (right below the bio), drastically improving conversion rates for email captures.

### 🛠️ Changes Made
- **Database:** 
  - Added a `Subscriber` model in `prisma/schema.prisma` to link captured emails to a specific `User`.
  - Added an `enableEmailCapture` boolean field to the `User` model.
- **Public Profile (`app/[username]`):** 
  - Created a new `NewsletterSubscribeBlock` component.
  - Conditionally rendered the block in `ProfileCard.tsx` if the profile owner has the feature enabled.
- **Dashboard (`app/dashboard`):** 
  - Added an "Email Subscribers" section in `DashboardClient.tsx`.
  - Profile owners can toggle the capture block on/off via a new `PUT /api/settings` route.
  - Added a dedicated view to see total subscribers, a list of recent sign-ups, and an **Export CSV** button.
- **API Routes:**
  - `POST /api/subscribe`: Safely handles email submissions from the public profile.
  - `GET /api/subscribers/export`: Generates and streams a CSV of the user's captured emails.
  - `PUT /api/settings`: Updates the `enableEmailCapture` flag on the user's profile.

### 📸 UI Previews
- **Public Profile:** Visitors see an inline `<input type="email">` and a **Subscribe** button right below the bio.
- **Dashboard:** A new section within the "Links" tab that displays total subscribers, recent entries, and an Export CSV button.

### ✅ Acceptance Criteria Met
- [x] Profile owners can toggle the email capture block on or off.
- [x] Visitors can enter their email on the public profile and see a success toast.
- [x] The profile owner can view a list of captured emails in their dashboard.
- [x] Subscribed emails can be exported cleanly as a CSV file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional email capture to profile pages.
  * Visitors can subscribe to newsletters with their email address.
  * Dashboard users can enable or disable email capture.
  * Added subscriber count, email list, and CSV export.
  * Duplicate subscriptions are handled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->