### PR TITLE
feat: add native web share API button for mobile sharing (#520)

### DIFF
--- a/app/[username]/ShareProfileButton.tsx
+++ b/app/[username]/ShareProfileButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Share } from "lucide-react";
+import toast from "react-hot-toast";
+
+export function ShareProfileButton() {
+  const handleShare = async () => {
+    const url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Check out my links",
+          url: url,
+        });
+      } catch (err) {
+        // User cancelled or error occurred
+      }
+    } else {
+      navigator.clipboard.writeText(url);
+      toast.success("Link copied to clipboard!");
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="absolute top-4 right-4 p-2.5 rounded-full bg-background/50 hover:bg-background/80 backdrop-blur-sm border border-border text-muted-foreground transition-all duration-200 z-50 hover:text-foreground"
+      aria-label="Share Profile"
+    >
+      <Share className="w-5 h-5" />
+    </button>
+  );
+}

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { ProfileCard } from "./ProfileCard";
 import { ProfileFooter } from "./ProfileFooter";
 import { resolveUserByUsername } from "@/lib/userLookup";
+import { ShareProfileButton } from "./ShareProfileButton";
 
 export async function generateMetadata({ params }: { params: Promise<{ username: string }> }) {
     try {
@@ -111,7 +112,8 @@ export default async function PublicProfile({
   });
 
   return (
-    <main className={`min-h-screen px-4 py-16 theme-${user.theme || "default"}`}>
+    <main className={`min-h-screen relative px-4 py-16 theme-${user.theme || "default"}`}>
+      <ShareProfileButton />
       <div className="mx-auto max-w-md">
         <ProfileCard
           user={{


### PR DESCRIPTION
### 📝 Description

**Fixes #520**

This PR adds a native "Share Profile" button to the public LinkID profile page (`app/[username]/page.tsx`). 

When visitors view a LinkID profile on a mobile device, they can now use their device's native sharing menu to share the profile via WhatsApp, iMessage, Twitter, etc., without having to manually copy the URL. 

### ✨ Features
* Added a new `ShareProfileButton` component utilizing the lightweight Web Share API (`navigator.share`).
* Positioned a subtle, styled share icon (from `lucide-react`) at the top right of the public profile page.
* **Smart Fallback Mechanism:** For desktop browsers or devices where `navigator.share` is unsupported, the button gracefully falls back to copying the profile URL to the clipboard and triggering a success toast notification via `react-hot-toast`.

### 🛠️ Changes Made
* `app/[username]/ShareProfileButton.tsx`: Created the new client component for handling the share action.
* `app/[username]/page.tsx`: Integrated the `ShareProfileButton` into the main profile view.

### 📸 UI Behavior
* **Mobile (Supported):** Clicking the button slides up the standard iOS/Android share sheet.
* **Desktop (Unsupported):** Clicking the button copies the URL to the clipboard and shows a "Link copied to clipboard!" toast message.