### PR TITLE
feat: add support for Kaggle and GeeksforGeeks platforms (#544)

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,6 +17,8 @@ export const PLATFORMS = {
     X: "x",
     TWITCH: "twitch",
     DISCORD: "discord",
+    KAGGLE: "kaggle",
+    GEEKSFORGEEKS: "geeksforgeeks",
 } as const;
 
 export type PlatformKey = keyof typeof PLATFORMS;

--- a/lib/platformHelpers.ts
+++ b/lib/platformHelpers.ts
@@ -11,7 +11,8 @@ export const formatLabel = (key: string) => {
         devto: "Dev.to",
         codeforces: "Codeforces",
         codechef: "CodeChef",
-
+        kaggle: "Kaggle",
+        geeksforgeeks: "GeeksforGeeks",
     };
     return exceptions[key] || key.charAt(0).toUpperCase() + key.slice(1);
 };

--- a/lib/platformIcons.ts
+++ b/lib/platformIcons.ts
@@ -16,6 +16,8 @@ import {
     SiDevdotto,
     SiCodechef,
     SiCodeforces,
+    SiKaggle,
+    SiGeeksforgeeks,
 } from "react-icons/si";
 
 import type { ComponentType, SVGProps } from "react";
@@ -38,6 +40,8 @@ export const PLATFORMS = {
     dribbble: { icon: FaDribbble, name: "Dribbble" },
     codechef: { icon: SiCodechef, name: "CodeChef" },
     codeforces: { icon: SiCodeforces, name: "Codeforces" },
+    kaggle: { icon: SiKaggle, name: "Kaggle" },
+    geeksforgeeks: { icon: SiGeeksforgeeks, name: "GeeksforGeeks" },
 } as const;
 
 export const PLATFORM_ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> =

--- a/lib/platforms.test.ts
+++ b/lib/platforms.test.ts
@@ -11,7 +11,7 @@ test("isKnownPlatform returns true for every declared platform", () => {
         PLATFORMS.GITHUB, PLATFORMS.LINKEDIN, "leetcode", PLATFORMS.YOUTUBE, "x",
         PLATFORMS.FACEBOOK, PLATFORMS.INSTAGRAM, "discord", "twitch",
         "hashnode", "devto", PLATFORMS.MEDIUM, "dribbble", PLATFORMS.WEBSITE,
-        "codeforces", "codechef",
+        "codeforces", "codechef", PLATFORMS.KAGGLE, PLATFORMS.GEEKSFORGEEKS,
     ];
     for (const p of known) {
         assert.equal(isKnownPlatform(p), true, `expected true for "${p}"`);
@@ -59,6 +59,11 @@ test("validatePlatformUrl accepts valid URLs for each platform", () => {
     assert.equal(validatePlatformUrl("dribbble", "https://dribbble.com/designer"), true);
     assert.equal(validatePlatformUrl("codeforces", "https://codeforces.com/profile/tourist"), true);
     assert.equal(validatePlatformUrl("codechef", "https://www.codechef.com/users/tourist"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.KAGGLE, "https://kaggle.com/alexisbcook"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.KAGGLE, "https://www.kaggle.com/alexisbcook"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.GEEKSFORGEEKS, "https://geeksforgeeks.org/user/gfguser"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.GEEKSFORGEEKS, "https://www.geeksforgeeks.org/user/gfguser"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.GEEKSFORGEEKS, "https://auth.geeksforgeeks.org/user/gfguser"), true);
     assert.equal(validatePlatformUrl(PLATFORMS.WEBSITE, "https://my-portfolio.com"), true);
     assert.equal(validatePlatformUrl(PLATFORMS.WEBSITE, "https://blog.example.com/posts"), true);
 });
@@ -71,7 +76,8 @@ test("validatePlatformUrl rejects URLs that don't match the platform", () => {
     assert.equal(validatePlatformUrl("twitch", "https://youtube.com/@streamer"), false);
     assert.equal(validatePlatformUrl("codeforces", "https://codechef.com/users/tourist"), false);
     assert.equal(validatePlatformUrl("codechef", "https://codeforces.com/profile/tourist"), false);
-
+    assert.equal(validatePlatformUrl(PLATFORMS.KAGGLE, "https://geeksforgeeks.org/user/gfguser"), false);
+    assert.equal(validatePlatformUrl(PLATFORMS.GEEKSFORGEEKS, "https://kaggle.com/alexisbcook"), false);
 });
 
 test("validatePlatformUrl rejects cross-platform URL swaps", () => {
@@ -97,7 +103,8 @@ test("validatePlatformUrl rejects cross-platform URL swaps", () => {
     assert.equal(validatePlatformUrl("dribbble", "https://figma.com/@designer"), false);
     assert.equal(validatePlatformUrl("codeforces", "https://codechef.com/users/tourist"), false);
     assert.equal(validatePlatformUrl("codechef", "https://codeforces.com/profile/tourist"), false);
-
+    assert.equal(validatePlatformUrl(PLATFORMS.KAGGLE, "https://leetcode.com/jsmith"), false);
+    assert.equal(validatePlatformUrl(PLATFORMS.GEEKSFORGEEKS, "https://codeforces.com/profile/tourist"), false);
 });
 
 test("validatePlatformUrl rejects LinkedIn /messaging/ and /feed/ paths", () => {

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -18,6 +18,8 @@ export type Platform =
     | "dribbble"
     | "codeforces"
     | "codechef"
+    | "kaggle"
+    | "geeksforgeeks"
     | "website";
 
 
@@ -46,6 +48,8 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     dribbble: /^https?:\/\/(www\.)?dribbble\.com\/[A-Za-z0-9_-]+\/?(\?.*)?$/i,
     codechef: /^https?:\/\/(www\.)?codechef\.com\/users\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
     codeforces: /^https?:\/\/(www\.)?codeforces\.com\/profile\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
+    kaggle: /^https?:\/\/(www\.)?kaggle\.com\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
+    geeksforgeeks: /^https?:\/\/(www\.|auth\.)?geeksforgeeks\.org\/user\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i,
     website: /^https?:\/\/.+/i,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,7 +5426,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/cors": {


### PR DESCRIPTION
## Summary
Closes #544

This PR adds support for **Kaggle** (`kaggle.com/username`) and **GeeksforGeeks** (`geeksforgeeks.org/user/username`) platforms across LinkID, enabling data science professionals and competitive programmers to showcase their profiles seamlessly.

## Proposed Changes
- **Constants** (`lib/constants.ts`): Added `KAGGLE: "kaggle"` and `GEEKSFORGEEKS: "geeksforgeeks"` to the `PLATFORMS` map.
- **Platform Types & URL Validation** (`lib/platforms.ts`):
  - Extended `Platform` union type to include `"kaggle"` and `"geeksforgeeks"`.
  - Added URL regex validation patterns in `PLATFORM_PATTERNS`:
    - Kaggle: `/^https?:\/\/(www\.)?kaggle\.com\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i`
    - GeeksforGeeks: `/^https?:\/\/(www\.|auth\.)?geeksforgeeks\.org\/user\/[A-Za-z0-9_.-]+\/?(\?.*)?$/i`
- **Icons & Metadata** (`lib/platformIcons.ts`): Imported `SiKaggle` and `SiGeeksforgeeks` from `react-icons/si` and mapped them into `PLATFORMS`.
- **Label Formatting** (`lib/platformHelpers.ts`): Added display name formatting exceptions for `"Kaggle"` and `"GeeksforGeeks"`.
- **Tests** (`lib/platforms.test.ts`): Added tests covering `isKnownPlatform`, `validatePlatformUrl` valid/invalid URL checks, and cross-platform swap rejections.

## Verification
- Executed production build (`prisma generate && next build`): Compiled cleanly with zero errors.
- Ran node test runner suite: `npx tsx --test --experimental-test-module-mocks lib/platforms.test.ts lib/platform.test.ts` (all 31 subtests passed).
- Verified runtime platform detection (`detectPlatform`) and URL validation (`validatePlatformUrl`) for both Kaggle and GeeksforGeeks URLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kaggle and GeeksforGeeks profiles.
  * Added platform icons and correctly formatted display names.
  * Added platform detection and URL validation for both services.
* **Tests**
  * Expanded validation coverage for supported, invalid, and cross-platform profile URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->