### PR TITLE
feat: implement multiple profile layout options (grid vs list)

### DIFF
--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -34,6 +34,7 @@ export function ProfileCard(props: ProfileCardProps) {
                     links={user.links ?? []}
                     username={username}
                     isOwner={isOwner}
+                    layoutStyle={user.layoutStyle}
                 />
 
                 {showCTA && <ProfileCTA />}

--- a/app/[username]/ProfileLinkItem.tsx
+++ b/app/[username]/ProfileLinkItem.tsx
@@ -31,7 +31,7 @@ export function ProfileLinkItem({ link, username, layoutStyle }: ProfileLinks) {
                     <Icon className="h-6 w-6" />
                 </div>
                 <span className="font-medium text-xs text-center truncate w-full capitalize">
-                    {link.label}
+                    {link.label || link.platform}
                 </span>
             </a>
         );
@@ -51,7 +51,7 @@ export function ProfileLinkItem({ link, username, layoutStyle }: ProfileLinks) {
                 </div>
 
                 <span className="font-medium capitalize">
-                    {link.label}
+                    {link.label || link.platform}
                 </span>
             </div>
 

--- a/app/[username]/ProfileLinkItem.tsx
+++ b/app/[username]/ProfileLinkItem.tsx
@@ -12,11 +12,30 @@ import { ProfileLinks } from "./types/type";
  * @param {string} props.username - The profile owner's username for routing.
  * @returns {JSX.Element} The rendered link item component.
  */
-export function ProfileLinkItem({ link, username }: ProfileLinks) {
+export function ProfileLinkItem({ link, username, layoutStyle }: ProfileLinks) {
     const Icon =
         PLATFORM_ICONS[link.platform] ?? Globe;
 
     const ariaLabel = `Visit ${link.label || link.platform}`;
+
+    if (layoutStyle === "GRID") {
+        return (
+            <a
+                href={`/${username}/${link.alias || link.platform}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={ariaLabel}
+                className="group flex flex-col items-center justify-center gap-2 rounded-xl border bg-background p-4 transition hover:bg-muted hover:scale-105 aspect-square"
+            >
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted group-hover:bg-background transition-colors">
+                    <Icon className="h-6 w-6" />
+                </div>
+                <span className="font-medium text-xs text-center truncate w-full capitalize">
+                    {link.label}
+                </span>
+            </a>
+        );
+    }
 
     return (
         <a

--- a/app/[username]/ProfileLinks.tsx
+++ b/app/[username]/ProfileLinks.tsx
@@ -16,7 +16,7 @@ export function ProfileLinks({
 
     const isGrid = layoutStyle === "GRID";
     const containerClass = isGrid 
-        ? "grid grid-cols-3 md:grid-cols-4 gap-4"
+        ? "grid grid-cols-2 md:grid-cols-4 gap-4"
         : "space-y-3";
 
     return (

--- a/app/[username]/ProfileLinks.tsx
+++ b/app/[username]/ProfileLinks.tsx
@@ -6,6 +6,7 @@ export function ProfileLinks({
     links,
     username,
     isOwner,
+    layoutStyle,
 }: ProfileLinksProps) {
     const safeLinks = links ?? [];
 
@@ -13,13 +14,19 @@ export function ProfileLinks({
         return <EmptyProfileState isOwner={isOwner} />;
     }
 
+    const isGrid = layoutStyle === "GRID";
+    const containerClass = isGrid 
+        ? "grid grid-cols-3 md:grid-cols-4 gap-4"
+        : "space-y-3";
+
     return (
-        <div className="space-y-3">
+        <div className={containerClass}>
             {safeLinks.map((link) => (
                 <ProfileLinkItem
                     key={link.id}
                     link={link}
                     username={username}
+                    layoutStyle={layoutStyle}
                 />
             ))}
         </div>

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -129,6 +129,7 @@ export default async function PublicProfile({
             links: activeLinks,
             resumeUrl: publicUserData?.resumeUrl ?? null,
             enableEmailCapture: user.enableEmailCapture,
+            layoutStyle: user.layoutStyle,
           }}
           username={resolved.canonicalUsername}
           showCTA={!session}

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -19,6 +19,8 @@ export type PlatformParams = {
     username: string;
 }
 
+export type LayoutStyle = "LIST" | "GRID";
+
 export type User = {
     user: {
         name: string | null;
@@ -28,7 +30,7 @@ export type User = {
         links?: Link[];
         resumeUrl?: string | null;
         enableEmailCapture?: boolean;
-        layoutStyle?: string;
+        layoutStyle?: LayoutStyle | string;
     };
     username: string;
     showCTA: boolean;
@@ -43,7 +45,7 @@ export type ProfileLinksProps = {
     links?: Link[];
     username: string;
     isOwner: boolean;
-    layoutStyle?: string;
+    layoutStyle?: LayoutStyle | string;
 };
 
 export type ProfileHeader = {
@@ -56,6 +58,6 @@ export type ProfileHeader = {
 export type ProfileLinks = {
     link: Link;
     username: string;
-    layoutStyle?: string;
+    layoutStyle?: LayoutStyle | string;
 }
 

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -28,6 +28,7 @@ export type User = {
         links?: Link[];
         resumeUrl?: string | null;
         enableEmailCapture?: boolean;
+        layoutStyle?: string;
     };
     username: string;
     showCTA: boolean;
@@ -42,6 +43,7 @@ export type ProfileLinksProps = {
     links?: Link[];
     username: string;
     isOwner: boolean;
+    layoutStyle?: string;
 };
 
 export type ProfileHeader = {
@@ -54,5 +56,6 @@ export type ProfileHeader = {
 export type ProfileLinks = {
     link: Link;
     username: string;
+    layoutStyle?: string;
 }
 

--- a/app/api/user/layout/route.test.ts
+++ b/app/api/user/layout/route.test.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from "next/server";
+import { PATCH } from "./route";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+
+jest.mock("next-auth", () => ({
+    getServerSession: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => ({
+    __esModule: true,
+    default: {
+        user: {
+            update: jest.fn(),
+        },
+    },
+}));
+
+describe("PATCH /api/user/layout", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return 401 if unauthorized", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+
+        const req = new NextRequest("http://localhost/api/user/layout", {
+            method: "PATCH",
+            body: JSON.stringify({ layoutStyle: "GRID" }),
+        });
+
+        const res = await PATCH(req);
+        expect(res.status).toBe(401);
+        const data = await res.json();
+        expect(data.error).toBe("Unauthorized");
+    });
+
+    it("should return 400 for invalid layoutStyle", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({
+            user: { email: "test@example.com" },
+        });
+
+        const req = new NextRequest("http://localhost/api/user/layout", {
+            method: "PATCH",
+            body: JSON.stringify({ layoutStyle: "INVALID" }),
+        });
+
+        const res = await PATCH(req);
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toBe("Invalid layout style");
+    });
+
+    it("should return 200 and update layoutStyle", async () => {
+        (getServerSession as jest.Mock).mockResolvedValue({
+            user: { email: "test@example.com" },
+        });
+        (prisma.user.update as jest.Mock).mockResolvedValue({
+            layoutStyle: "GRID",
+        });
+
+        const req = new NextRequest("http://localhost/api/user/layout", {
+            method: "PATCH",
+            body: JSON.stringify({ layoutStyle: "GRID" }),
+        });
+
+        const res = await PATCH(req);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
+        expect(data.layoutStyle).toBe("GRID");
+
+        expect(prisma.user.update).toHaveBeenCalledWith({
+            where: { email: "test@example.com" },
+            data: { layoutStyle: "GRID" },
+        });
+    });
+});

--- a/app/api/user/layout/route.ts
+++ b/app/api/user/layout/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { LayoutStyle } from "@/app/[username]/types/type";
 
 export async function PATCH(req: NextRequest) {
     try {
@@ -17,9 +18,11 @@ export async function PATCH(req: NextRequest) {
             return NextResponse.json({ error: "Invalid layout style" }, { status: 400 });
         }
 
+        const validLayout: LayoutStyle = layoutStyle;
+
         const updatedUser = await prisma.user.update({
             where: { email: session.user.email },
-            data: { layoutStyle },
+            data: { layoutStyle: validLayout },
         });
 
         return NextResponse.json({ success: true, layoutStyle: updatedUser.layoutStyle }, { status: 200 });

--- a/app/api/user/layout/route.ts
+++ b/app/api/user/layout/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function PATCH(req: NextRequest) {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.email) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await req.json();
+        const { layoutStyle } = body;
+
+        if (layoutStyle !== "LIST" && layoutStyle !== "GRID") {
+            return NextResponse.json({ error: "Invalid layout style" }, { status: 400 });
+        }
+
+        const updatedUser = await prisma.user.update({
+            where: { email: session.user.email },
+            data: { layoutStyle },
+        });
+
+        return NextResponse.json({ success: true, layoutStyle: updatedUser.layoutStyle }, { status: 200 });
+    } catch (error) {
+        console.error("Failed to update layout style:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/app/dashboard/AppearanceSection.tsx
+++ b/app/dashboard/AppearanceSection.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { getCsrfToken } from "@/lib/csrfClient";
 import toast from "react-hot-toast";
+import { LayoutList, LayoutGrid } from "lucide-react";
 
 const THEMES = [
     { id: "default", label: "Default", color: "#e2e8f0", bg: "#f8fafc" },
@@ -13,17 +14,23 @@ const THEMES = [
 
 export function AppearanceSection({
     initialTheme,
+    initialLayout,
     onUpdateTheme,
+    onUpdateLayout,
 }: {
     initialTheme: string;
+    initialLayout: string;
     onUpdateTheme: (theme: string) => void;
+    onUpdateLayout: (layout: string) => void;
 }) {
-    const [selected, setSelected] = useState(initialTheme || "default");
-    const [saving, setSaving] = useState(false);
+    const [selectedTheme, setSelectedTheme] = useState(initialTheme || "default");
+    const [selectedLayout, setSelectedLayout] = useState(initialLayout || "LIST");
+    const [savingTheme, setSavingTheme] = useState(false);
+    const [savingLayout, setSavingLayout] = useState(false);
 
-    async function handleSave(themeId: string) {
-        setSelected(themeId);
-        setSaving(true);
+    async function handleSaveTheme(themeId: string) {
+        setSelectedTheme(themeId);
+        setSavingTheme(true);
         try {
             const csrfToken = await getCsrfToken();
             const res = await fetch("/api/user/theme", {
@@ -46,12 +53,85 @@ export function AppearanceSection({
             toast.error("Failed to update theme");
             console.error(error);
         } finally {
-            setSaving(false);
+            setSavingTheme(false);
+        }
+    }
+
+    async function handleSaveLayout(layoutId: string) {
+        setSelectedLayout(layoutId);
+        setSavingLayout(true);
+        try {
+            const csrfToken = await getCsrfToken();
+            const res = await fetch("/api/user/layout", {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-csrf-token": csrfToken,
+                },
+                body: JSON.stringify({ layoutStyle: layoutId }),
+            });
+            
+            if (!res.ok) {
+                throw new Error("Failed to save layout");
+            }
+
+            const data = await res.json();
+            onUpdateLayout(data.layoutStyle);
+            toast.success("Layout updated successfully!");
+        } catch (error) {
+            toast.error("Failed to update layout");
+            console.error(error);
+        } finally {
+            setSavingLayout(false);
         }
     }
 
     return (
-        <section className="space-y-6">
+        <section className="space-y-10">
+            {/* Layout Section */}
+            <div className="space-y-6">
+                <div className="space-y-1">
+                    <h2 className="text-xl font-semibold">Profile Layout</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Choose how your links are displayed on your profile.
+                    </p>
+                </div>
+                
+                <div className="grid grid-cols-2 gap-4 max-w-sm">
+                    <button
+                        onClick={() => handleSaveLayout("LIST")}
+                        disabled={savingLayout}
+                        className={`group relative flex flex-col items-center gap-3 p-4 rounded-xl border-2 transition-all ${
+                            selectedLayout === "LIST"
+                                ? "border-primary bg-primary/5"
+                                : "border-border hover:border-primary/50 hover:bg-accent"
+                        }`}
+                    >
+                        <div className="w-16 h-16 flex items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                            <LayoutList size={32} />
+                        </div>
+                        <span className="text-sm font-medium">List</span>
+                    </button>
+                    
+                    <button
+                        onClick={() => handleSaveLayout("GRID")}
+                        disabled={savingLayout}
+                        className={`group relative flex flex-col items-center gap-3 p-4 rounded-xl border-2 transition-all ${
+                            selectedLayout === "GRID"
+                                ? "border-primary bg-primary/5"
+                                : "border-border hover:border-primary/50 hover:bg-accent"
+                        }`}
+                    >
+                        <div className="w-16 h-16 flex items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                            <LayoutGrid size={32} />
+                        </div>
+                        <span className="text-sm font-medium">Grid</span>
+                    </button>
+                </div>
+            </div>
+
+            {/* Theme Section */}
+            <div className="space-y-6">
             <div className="space-y-1">
                 <h2 className="text-xl font-semibold">Profile Theme</h2>
                 <p className="text-sm text-muted-foreground">
@@ -63,10 +143,10 @@ export function AppearanceSection({
                 {THEMES.map((theme) => (
                     <button
                         key={theme.id}
-                        onClick={() => handleSave(theme.id)}
-                        disabled={saving}
+                        onClick={() => handleSaveTheme(theme.id)}
+                        disabled={savingTheme}
                         className={`group relative flex flex-col items-center gap-3 p-4 rounded-xl border-2 transition-all ${
-                            selected === theme.id
+                            selectedTheme === theme.id
                                 ? "border-primary bg-primary/5"
                                 : "border-border hover:border-primary/50 hover:bg-accent"
                         }`}
@@ -83,6 +163,7 @@ export function AppearanceSection({
                         <span className="text-sm font-medium">{theme.label}</span>
                     </button>
                 ))}
+            </div>
             </div>
         </section>
     );

--- a/app/dashboard/AppearanceSection.tsx
+++ b/app/dashboard/AppearanceSection.tsx
@@ -12,6 +12,8 @@ const THEMES = [
     { id: "sunset", label: "Sunset", color: "#c2410c", bg: "#fffbeb" },
 ];
 
+import { LayoutStyle } from "@/app/[username]/types/type";
+
 export function AppearanceSection({
     initialTheme,
     initialLayout,
@@ -19,9 +21,9 @@ export function AppearanceSection({
     onUpdateLayout,
 }: {
     initialTheme: string;
-    initialLayout: string;
+    initialLayout: LayoutStyle;
     onUpdateTheme: (theme: string) => void;
-    onUpdateLayout: (layout: string) => void;
+    onUpdateLayout: (layout: LayoutStyle) => void;
 }) {
     const [selectedTheme, setSelectedTheme] = useState(initialTheme || "default");
     const [selectedLayout, setSelectedLayout] = useState(initialLayout || "LIST");
@@ -57,7 +59,8 @@ export function AppearanceSection({
         }
     }
 
-    async function handleSaveLayout(layoutId: string) {
+    async function handleSaveLayout(layoutId: LayoutStyle) {
+        const previousLayout = selectedLayout as LayoutStyle;
         setSelectedLayout(layoutId);
         setSavingLayout(true);
         try {
@@ -79,6 +82,7 @@ export function AppearanceSection({
             onUpdateLayout(data.layoutStyle);
             toast.success("Layout updated successfully!");
         } catch (error) {
+            setSelectedLayout(previousLayout);
             toast.error("Failed to update layout");
             console.error(error);
         } finally {

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -17,6 +17,7 @@ export default function DashboardClient({
     initialTheme,
     initialSeoTitle,
     initialSeoDescription,
+    initialLayout,
     qrCode,
     enableEmailCapture,
     subscribers = [],
@@ -26,12 +27,14 @@ export default function DashboardClient({
     initialTheme?: string;
     initialSeoTitle?: string;
     initialSeoDescription?: string;
+    initialLayout?: string;
     qrCode?: React.ReactNode;
     enableEmailCapture?: boolean;
     subscribers?: { id: string; email: string; createdAt: Date }[];
 }) {
     const [links, setLinks] = useState(initialLinks);
     const [theme, setTheme] = useState(initialTheme || "default");
+    const [layoutStyle, setLayoutStyle] = useState(initialLayout || "LIST");
     const [seoTitle, setSeoTitle] = useState(initialSeoTitle || "");
     const [seoDescription, setSeoDescription] = useState(initialSeoDescription || "");
     const [activeTab, setActiveTab] = useState<"links" | "appearance" | "seo">("links");
@@ -291,7 +294,9 @@ export default function DashboardClient({
                 ) : activeTab === 'appearance' ? (
                     <AppearanceSection 
                         initialTheme={theme} 
+                        initialLayout={layoutStyle}
                         onUpdateTheme={setTheme} 
+                        onUpdateLayout={setLayoutStyle}
                     />
                 ) : (
                     <SeoSection 

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -10,6 +10,7 @@ import { AnalyticsOverview } from "./AnalyticsOverview";
 import { VersionHistory } from "@/components/dashboard/VersionHistory";
 import { AppearanceSection } from "./AppearanceSection";
 import { SeoSection } from "./SeoSection";
+import { LayoutStyle } from "@/app/[username]/types/type";
 
 export default function DashboardClient({
     username,
@@ -27,14 +28,14 @@ export default function DashboardClient({
     initialTheme?: string;
     initialSeoTitle?: string;
     initialSeoDescription?: string;
-    initialLayout?: string;
+    initialLayout?: LayoutStyle;
     qrCode?: React.ReactNode;
     enableEmailCapture?: boolean;
     subscribers?: { id: string; email: string; createdAt: Date }[];
 }) {
     const [links, setLinks] = useState(initialLinks);
     const [theme, setTheme] = useState(initialTheme || "default");
-    const [layoutStyle, setLayoutStyle] = useState(initialLayout || "LIST");
+    const [layoutStyle, setLayoutStyle] = useState<LayoutStyle>(initialLayout || "LIST");
     const [seoTitle, setSeoTitle] = useState(initialSeoTitle || "");
     const [seoDescription, setSeoDescription] = useState(initialSeoDescription || "");
     const [activeTab, setActiveTab] = useState<"links" | "appearance" | "seo">("links");

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ export default async function DashboardPage() {
             username={user.username}
             initialLinks={user.links}
             initialTheme={user.theme}
+            initialLayout={user.layoutStyle}
             initialSeoTitle={user.seoTitle || ""}
             initialSeoDescription={user.seoDescription || ""}
             qrCode={<QRCode />} 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,6 +6,11 @@ datasource db {
   provider = "postgresql"
 }
 
+enum LayoutStyle {
+  LIST
+  GRID
+}
+
 model User {
   id            String   @id @default(uuid())
   name          String?
@@ -28,6 +33,7 @@ model User {
   themeColor          String   @default("slate")
   themeCustom         String?
   enableEmailCapture  Boolean  @default(false)
+  layoutStyle         LayoutStyle @default(LIST)
 
   links         Link[]
   accounts      Account[]


### PR DESCRIPTION
## Description
Resolves #551 

This PR introduces the **Multiple Profile Layout Options (Grid vs. List)** feature, allowing users to choose how their links are displayed on their public profile. Users can now easily switch between the standard vertical list or a new, space-saving grid layout directly from their dashboard settings.

## 🚀 Changes Made
- **Database Schema**: 
  - Added a new `LayoutStyle` enum (`LIST`, `GRID`).
  - Added `layoutStyle` column to the `User` model, defaulting to `LIST`.
- **Dashboard UI**:
  - Updated `DashboardClient.tsx` and `AppearanceSection.tsx` to include a visually intuitive Layout Mode switcher featuring `List` and `Grid` icons.
  - Implemented `app/api/user/layout/route.ts` API route to securely save the layout preference to the database.
- **Public Profile Display**:
  - Integrated the layout setting dynamically in `ProfileCard.tsx` and `ProfileLinks.tsx`.
  - When the "GRID" layout is selected, links are rendered using CSS grid layout (`grid-cols-3` or `grid-cols-4` responsively).
  - Designed a square "app-like" button for `ProfileLinkItem.tsx` that triggers conditionally for Grid layouts, featuring a larger platform icon and centered, truncated text underneath.

## 🎯 Acceptance Criteria Met
- [x] Users can successfully save their layout preference to the database.
- [x] The public profile conditionally renders the links based on the saved layout.
- [x] The Grid layout is fully responsive and breaks down smoothly on mobile screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile layout customization with **List** and **Grid** options.
  * Users can select and save their preferred profile layout from the Appearance settings.
  * Public profiles now display links in the selected layout, including square grid-style link cards.
  * Layout preferences are retained and applied when viewing the profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->