### PR TITLE
feat(analytics): add top referrer, device, and country breakdowns

### DIFF
--- a/app/dashboard/AnalyticsOverview.tsx
+++ b/app/dashboard/AnalyticsOverview.tsx
@@ -33,6 +33,7 @@ import {
     XAxis,
     YAxis,
 } from "recharts";
+import type { BreakdownEntry } from "@/lib/analyticsMath";
 
 type LinkAnalytics = {
     id: string;
@@ -91,6 +92,9 @@ type AnalyticsSummary = {
     platformPerformance: PlatformPerformanceEntry[];
     recentActivity: RecentActivity;
     comparison: PeriodComparison;
+    topReferrers: BreakdownEntry[];
+    topDevices: BreakdownEntry[];
+    topCountries: BreakdownEntry[];
 };
 
 const PIE_COLORS = ["#6366f1", "#22c55e", "#f59e0b", "#ec4899", "#06b6d4", "#a855f7", "#ef4444"];
@@ -104,6 +108,35 @@ function formatTrend(change: number | "new" | null | undefined) {
     if (rounded > 0) return { text: `+${rounded}%`, className: "text-green-600" };
     if (rounded < 0) return { text: `${rounded}%`, className: "text-red-600" };
     return { text: "0%", className: "text-muted-foreground" };
+}
+
+function BreakdownList({ entries }: { entries: BreakdownEntry[] }) {
+    if (entries.length === 0) {
+        return <p className="text-sm text-muted-foreground">No data yet.</p>;
+    }
+
+    const max = Math.max(...entries.map((e) => e.count));
+
+    return (
+        <div className="space-y-2">
+            {entries.map((entry) => (
+                <div key={entry.label} className="space-y-1">
+                    <div className="flex items-center justify-between text-xs">
+                        <span className="truncate pr-2 font-medium">{entry.label}</span>
+                        <span className="shrink-0 text-muted-foreground">
+                            {entry.count.toLocaleString()}
+                        </span>
+                    </div>
+                    <div className="h-1.5 w-full rounded-full bg-muted">
+                        <div
+                            className="h-1.5 rounded-full bg-indigo-500"
+                            style={{ width: `${max > 0 ? (entry.count / max) * 100 : 0}%` }}
+                        />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
 }
 
 export function AnalyticsOverview() {
@@ -433,6 +466,53 @@ export function AnalyticsOverview() {
                     )}
                 </CardContent>
             </Card>
+
+            <div className="grid gap-4 lg:grid-cols-3">
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-sm font-medium text-muted-foreground">
+                            Top Referrers
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {loading ? (
+                            <p className="text-sm text-muted-foreground">Loading…</p>
+                        ) : (
+                            <BreakdownList entries={summary?.topReferrers ?? []} />
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-sm font-medium text-muted-foreground">
+                            Top Devices
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {loading ? (
+                            <p className="text-sm text-muted-foreground">Loading…</p>
+                        ) : (
+                            <BreakdownList entries={summary?.topDevices ?? []} />
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-sm font-medium text-muted-foreground">
+                            Top Countries
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {loading ? (
+                            <p className="text-sm text-muted-foreground">Loading…</p>
+                        ) : (
+                            <BreakdownList entries={summary?.topCountries ?? []} />
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
 
             <Card>
                 <CardHeader>

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { computePercentChange } from "@/lib/analyticsMath";
+import { buildTopBreakdown, computePercentChange } from "@/lib/analyticsMath";
 
 test("computePercentChange returns a positive percentage when clicks increased", () => {
     assert.strictEqual(computePercentChange(118, 100), 18);
@@ -24,4 +24,49 @@ test("computePercentChange returns null when both periods had zero clicks", () =
 
 test("computePercentChange returns -100 when clicks dropped to zero", () => {
     assert.strictEqual(computePercentChange(0, 50), -100);
+});
+
+test("buildTopBreakdown groups empty values and trims labels", () => {
+    const breakdown = buildTopBreakdown(
+        [
+            { key: null, count: 1 },
+            { key: "   ", count: 2 },
+            { key: "  google.com ", count: 4 },
+        ],
+        "Direct / Unknown"
+    );
+
+    assert.deepStrictEqual(breakdown, [
+        { label: "google.com", count: 4 },
+        { label: "Direct / Unknown", count: 3 },
+    ]);
+});
+
+test("buildTopBreakdown rolls overflow rows into Other", () => {
+    const breakdown = buildTopBreakdown(
+        [
+            { key: "one", count: 10 },
+            { key: "two", count: 9 },
+            { key: "three", count: 8 },
+            { key: "four", count: 7 },
+            { key: "five", count: 6 },
+            { key: "six", count: 5 },
+            { key: "seven", count: 4 },
+            { key: "eight", count: 3 },
+            { key: "nine", count: 2 },
+        ],
+        "Unknown"
+    );
+
+    assert.deepStrictEqual(breakdown, [
+        { label: "one", count: 10 },
+        { label: "two", count: 9 },
+        { label: "three", count: 8 },
+        { label: "four", count: 7 },
+        { label: "five", count: 6 },
+        { label: "six", count: 5 },
+        { label: "seven", count: 4 },
+        { label: "eight", count: 3 },
+        { label: "Other", count: 2 },
+    ]);
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -8,7 +8,8 @@ import {
 } from "@/lib/analyticsUtils";
 import { enqueueJob } from "@/lib/jobs";
 import prisma from "@/lib/prisma";
-import { computePercentChange } from "@/lib/analyticsMath";
+import { computePercentChange, buildTopBreakdown } from "@/lib/analyticsMath";
+
 
 const UNIQUE_VISITOR_WINDOW_HOURS = 24;
 
@@ -20,6 +21,7 @@ type PeriodComparison = {
     totalClicksChangePercent: number | "new" | null;
     uniqueClicksChangePercent: number | "new" | null;
 };
+
 
 
 
@@ -238,7 +240,16 @@ export async function getUserAnalyticsSummary(input: {
 
     const allowedComparison = rangeDays === 7 || rangeDays === 30 || rangeDays === 90;
 
-    const [totals, perLink, clicksOverTimeRaw, recentActivityEvent, previousTotals] = await Promise.all([
+    const [
+        totals,
+        perLink,
+        clicksOverTimeRaw,
+        recentActivityEvent,
+        previousTotals,
+        referrerGroups,
+        deviceGroups,
+        countryGroups,
+    ] = await Promise.all([
         prisma.dailyLinkAnalytics.aggregate({
             where: {
                 userId: input.userId,
@@ -302,6 +313,33 @@ export async function getUserAnalyticsSummary(input: {
                   _sum: { totalClicks: true, uniqueClicks: true },
               })
             : Promise.resolve(null),
+        prisma.clickEvent.groupBy({
+            by: ["referrer"],
+            where: {
+                userId: input.userId,
+                isBot: false,
+                ...(start !== null && { createdAt: { gte: start } }),
+            },
+            _count: { _all: true },
+        }),
+        prisma.clickEvent.groupBy({
+            by: ["deviceType"],
+            where: {
+                userId: input.userId,
+                isBot: false,
+                ...(start !== null && { createdAt: { gte: start } }),
+            },
+            _count: { _all: true },
+        }),
+        prisma.clickEvent.groupBy({
+            by: ["country"],
+            where: {
+                userId: input.userId,
+                isBot: false,
+                ...(start !== null && { createdAt: { gte: start } }),
+            },
+            _count: { _all: true },
+        }),
     ]);
 
     const clicksOverTime = clicksOverTimeRaw.map((entry) => ({
@@ -341,6 +379,21 @@ export async function getUserAnalyticsSummary(input: {
           }
         : null;
 
+    const topReferrers = buildTopBreakdown(
+        referrerGroups.map((g) => ({ key: g.referrer, count: g._count._all })),
+        "Direct / Unknown"
+    );
+
+    const topDevices = buildTopBreakdown(
+        deviceGroups.map((g) => ({ key: g.deviceType, count: g._count._all })),
+        "Unknown"
+    );
+
+    const topCountries = buildTopBreakdown(
+        countryGroups.map((g) => ({ key: g.country, count: g._count._all })),
+        "Unknown"
+    );
+
     if (perLink.length === 0) {
         return {
             rangeDays,
@@ -354,6 +407,9 @@ export async function getUserAnalyticsSummary(input: {
             platformPerformance: [],
             recentActivity: null,
             comparison,
+            topReferrers,
+            topDevices,
+            topCountries,
         };
     }
 
@@ -429,5 +485,8 @@ export async function getUserAnalyticsSummary(input: {
         platformPerformance,
         recentActivity,
         comparison,
+        topReferrers,
+        topDevices,
+        topCountries,
     };
 }

--- a/lib/analyticsMath.ts
+++ b/lib/analyticsMath.ts
@@ -4,3 +4,34 @@ export function computePercentChange(current: number, previous: number): number 
     }
     return ((current - previous) / previous) * 100;
 }
+
+const TOP_BREAKDOWN_LIMIT = 8;
+
+export type BreakdownEntry = {
+    label: string;
+    count: number;
+};
+
+export function buildTopBreakdown(
+    rows: { key: string | null; count: number }[],
+    fallbackLabel: string
+): BreakdownEntry[] {
+    const counts = new Map<string, number>();
+
+    for (const row of rows) {
+        const label = row.key && row.key.trim() ? row.key.trim() : fallbackLabel;
+        counts.set(label, (counts.get(label) ?? 0) + row.count);
+    }
+
+    const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+    const top = sorted.slice(0, TOP_BREAKDOWN_LIMIT);
+    const rest = sorted.slice(TOP_BREAKDOWN_LIMIT);
+    const otherCount = rest.reduce((sum, [, count]) => sum + count, 0);
+
+    const result: BreakdownEntry[] = top.map(([label, count]) => ({ label, count }));
+    if (otherCount > 0) {
+        result.push({ label: "Other", count: otherCount });
+    }
+
+    return result;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-icons": "^5.5.0",
         "react-image-crop": "^11.0.10",
         "recharts": "^3.9.2",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.5"
       },
@@ -13895,6 +13896,12 @@
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
       "devOptional": true
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-icons": "^5.5.0",
     "react-image-crop": "^11.0.10",
     "recharts": "^3.9.2",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.5"
   },


### PR DESCRIPTION
# fixed #542 

## Summary

This PR adds aggregated analytics breakdowns for **top referrers**, **device types**, and **visitor countries** to the analytics dashboard.

The backend now aggregates click data from `ClickEvent` for the selected date range and returns the results as part of the analytics summary. The dashboard displays these breakdowns as horizontal bar lists alongside the existing analytics cards, giving users better insight into where their traffic comes from and how visitors are accessing their links.

The implementation reuses the existing analytics filtering, excludes bot traffic, and requires no database changes.

---

## What Changed

### Backend

#### `lib/analytics.ts`

* Added aggregation logic for:

  * Top referrers
  * Top device types
  * Top visitor countries
* Reused the existing user and date-range filters so the breakdowns automatically respect the selected time period (7 / 30 / 90 / All).
* Excluded bot traffic (`isBot: true`) from all aggregations.
* Added friendly fallback labels for missing values:

  * **Direct / Unknown** for empty referrers
  * **Unknown** for missing countries
* Returned the new analytics fields in the summary response:

  * `topReferrers`
  * `topDevices`
  * `topCountries`

---

### Frontend

#### `app/dashboard/AnalyticsOverview.tsx`

* Added dashboard sections for:

  * Top Referrers
  * Top Devices
  * Top Countries
* Rendered each breakdown as a simple horizontal bar list using the existing dashboard styling.
* Integrated the new API response without affecting the existing analytics charts and summary cards.
* Resolved the local type conflict in the analytics overview component.

---

## Tests

### `lib/analytics.test.ts`

* Added tests covering the analytics breakdown helper.
* Verified aggregation results and fallback handling.
* Confirmed existing analytics functionality continues to work correctly.

---

## Verification

* Breakdown data is returned for referrers, devices, and countries.
* Bot traffic is excluded from all aggregations.
* Results respect the selected date range (7 / 30 / 90 / All).
* Friendly fallback labels are shown for missing referrers and countries.
* No database migration was required.
* Existing analytics functionality remains unchanged.

---

## Acceptance Criteria

* [x] Summary API response includes `topReferrers`, `topDevices`, and `topCountries`.
* [x] Bot clicks are excluded from all three breakdowns.
* [x] Breakdown respects the selected date range (7 / 30 / 90 / All).
* [x] Empty or missing referrers and countries use friendly fallback labels.
* [x] No database migration is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics breakdown cards for top referrers, devices, and countries.
  * Breakdown results show proportional bars, loading states, and clear empty-state messaging.
  * Unrecognized or missing values are grouped under a fallback label, with additional results summarized as “Other.”

* **Bug Fixes**
  * Improved analytics categorization by trimming labels and consolidating equivalent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->