### PR TITLE
fix(#546): improve YouTube URL validation for handles with dots and d…

### DIFF
--- a/lib/platforms.test.ts
+++ b/lib/platforms.test.ts
@@ -117,3 +117,39 @@ test("validatePlatformUrl rejects /messaging/ and /feed/ paths on any platform",
     assert.equal(validatePlatformUrl(PLATFORMS.WEBSITE, "https://example.com/messaging/inbox"), false);
     assert.equal(validatePlatformUrl(PLATFORMS.WEBSITE, "https://example.com/feed/update"), false);
 });
+
+// --- YouTube handle / URL validation (issue #546) ---
+
+test("validatePlatformUrl accepts YouTube @handles with dots and dashes", () => {
+    // Dots in handle — the exact case reported in #546
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@user.name.dev"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://www.youtube.com/@user.name"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@some-channel"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@some_channel.official"), true);
+    // Multiple consecutive dots / mixed separators
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@a.b.c.d"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@a-b.c_d"), true);
+});
+
+test("validatePlatformUrl accepts YouTube c/ custom URLs with dots", () => {
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/c/user.name.dev"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://www.youtube.com/c/my.channel"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/c/channel-name"), true);
+});
+
+test("validatePlatformUrl still accepts standard YouTube URL formats", () => {
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/channel/UC1234567890abcdef"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/shorts/hW9_8k8Gjks"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtu.be/dQw4w9WgXcQ"), true);
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/watch?v=dQw4w9WgXcQ"), true);
+});
+
+test("validatePlatformUrl rejects invalid YouTube URLs", () => {
+    // /results is explicitly blocklisted
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/results?search_query=test"), false);
+    // Wrong domain
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://vimeo.com/@user.name"), false);
+    // Bare @ with no handle name
+    assert.equal(validatePlatformUrl(PLATFORMS.YOUTUBE, "https://youtube.com/@"), false);
+});
+

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -33,7 +33,7 @@ const PLATFORM_PATTERNS: Record<Platform, RegExp> = {
     linkedin: /^https?:\/\/(www\.)?linkedin\.com\/.*$/i,
 
     leetcode: /^https?:\/\/(www\.)?leetcode\.com\/(u\/)?[A-Za-z0-9_-]+\/?(\?.*)?$/i,
-    youtube: /^https?:\/\/(www\.)?(youtube\.com\/(@[A-Za-z0-9_.-]+|channel\/[A-Za-z0-9_-]+|c\/[A-Za-z0-9_-]+|shorts\/[A-Za-z0-9_-]+|watch|playlist)|youtu\.be\/[A-Za-z0-9_-]+\/?)\/?(\?.*)?$/i,
+    youtube: /^https?:\/\/(www\.)?(youtube\.com\/(@[A-Za-z0-9_.-]+|channel\/[A-Za-z0-9_-]+|c\/[A-Za-z0-9_.-]+|shorts\/[A-Za-z0-9_-]+|watch|playlist)|youtu\.be\/[A-Za-z0-9_-]+\/?)\/?(\?.*)?$/i,
     x: /^https?:\/\/(www\.)?(x|twitter)\.com\/[A-Za-z0-9_]{1,15}\/?(\?.*)?$/i,
 
     // Generic domain catching ensures subpaths like /groups or /marketplace map to Facebook before validation.


### PR DESCRIPTION
Fixes #546 — valid YouTube channel URLs containing dots or dashes in handles (e.g. `https://youtube.com/@user.name.dev`) were failing validation and falling back to the generic `website` platform.

### Root Cause

The YouTube regex in [`lib/platforms.ts`](file:///d:/linkid/linkid/lib/platforms.ts) had **inconsistent character classes** across its sub-patterns:

| Path | Before | After |
|---|---|---|
| `@handle` | `[A-Za-z0-9_.-]+` ✅ | unchanged |
| `c/custom` | `[A-Za-z0-9_-]+` ❌ | `[A-Za-z0-9_.-]+` ✅ |
| `channel/` | `[A-Za-z0-9_-]+` ✅ | unchanged (channel IDs don't use dots) |

The `c/` legacy custom-URL branch was missing `.` from its character class, causing URLs like `youtube.com/c/user.name.dev` to silently fail. The `@` handle branch was already correct.

### Changes

- **[`lib/platforms.ts`](file:///d:/linkid/linkid/lib/platforms.ts)** — Added `.` to the `c/` segment in the YouTube regex (1-character change)
- **[`lib/platforms.test.ts`](file:///d:/linkid/linkid/lib/platforms.test.ts)** — Added 4 new test blocks covering:
  - `@handles` with dots (`@user.name.dev`) and dashes — the exact repro from #546
  - `c/` paths with dots (`c/user.name.dev`)
  - Standard formats as regression guards (`channel/`, `shorts/`, `youtu.be/`, `watch?v=`)
  - Rejection of `/results`, wrong domains, and bare `@` with no handle

### Testing

All new tests pass (`ok 77–80`). The 11 pre-existing failures are unrelated API integration tests that require a live database session and were failing before this change.

```
# tests 131  |  pass 120  |  fail 11 (pre-existing)
ok 77 - validatePlatformUrl accepts YouTube @handles with dots and dashes
ok 78 - validatePlatformUrl accepts YouTube c/ custom URLs with dots
ok 79 - validatePlatformUrl still accepts standard YouTube URL formats
ok 80 - validatePlatformUrl rejects invalid YouTube URLs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded YouTube URL validation coverage for handles and custom channel paths.
  * Confirmed support for channel, Shorts, short-link, and watch URLs.
  * Added checks rejecting invalid result pages, domains, and empty handles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->