### PR TITLE
feat: add link groups and collapsible folders (#554)

### DIFF
--- a/app/[username]/ProfileLinkGroup.tsx
+++ b/app/[username]/ProfileLinkGroup.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ProfileLinkItem } from "./ProfileLinkItem";
+import type { Link, LayoutStyle } from "./types/type";
+
+export function ProfileLinkGroup({
+    group,
+    username,
+    layoutStyle,
+}: {
+    group: Link;
+    username: string;
+    layoutStyle?: LayoutStyle | string;
+}) {
+    const [isOpen, setIsOpen] = useState(true);
+    const children = group.children || [];
+
+    if (children.length === 0) return null;
+
+    const isGrid = layoutStyle === "GRID";
+
+    return (
+        <div className="space-y-2">
+            <button
+                onClick={() => setIsOpen((v) => !v)}
+                className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-left transition-colors hover:bg-muted/50 group"
+                aria-expanded={isOpen}
+            >
+                <motion.div
+                    animate={{ rotate: isOpen ? 0 : -90 }}
+                    transition={{ duration: 0.2 }}
+                >
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                </motion.div>
+                <span className="font-semibold text-sm">{group.label}</span>
+                <span className="text-xs text-muted-foreground">
+                    ({children.length})
+                </span>
+            </button>
+
+            <AnimatePresence initial={false}>
+                {isOpen && (
+                    <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.25, ease: "easeInOut" }}
+                        className="overflow-hidden"
+                    >
+                        <div
+                            className={
+                                isGrid
+                                    ? "grid grid-cols-2 md:grid-cols-4 gap-4 pl-4 border-l-2 border-muted ml-2"
+                                    : "space-y-2 pl-4 border-l-2 border-muted ml-2"
+                            }
+                        >
+                            {children.map((link) => (
+                                <ProfileLinkItem
+                                    key={link.id}
+                                    link={link}
+                                    username={username}
+                                    layoutStyle={layoutStyle}
+                                />
+                            ))}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/app/[username]/ProfileLinks.tsx
+++ b/app/[username]/ProfileLinks.tsx
@@ -9,7 +9,12 @@ export function ProfileLinks({
     isOwner,
     layoutStyle,
 }: ProfileLinksProps) {
-    const safeLinks = links ?? [];
+    const safeLinks = (links ?? []).filter((item) => {
+        if (item.isGroup) {
+            return (item.children?.length ?? 0) > 0;
+        }
+        return true;
+    });
 
     if (safeLinks.length === 0) {
         return <EmptyProfileState isOwner={isOwner} />;
@@ -18,25 +23,13 @@ export function ProfileLinks({
     const isGrid = layoutStyle === "GRID";
 
     return (
-        <div className="space-y-3">
+        <div className={isGrid ? "grid grid-cols-2 md:grid-cols-4 gap-4" : "space-y-3"}>
             {safeLinks.map((item) => {
                 if (item.isGroup) {
                     return (
-                        <ProfileLinkGroup
-                            key={item.id}
-                            group={item}
-                            username={username}
-                            layoutStyle={layoutStyle}
-                        />
-                    );
-                }
-
-                // Top-level (ungrouped) links
-                if (isGrid) {
-                    return (
-                        <div key={item.id} className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                            <ProfileLinkItem
-                                link={item}
+                        <div key={item.id} className={isGrid ? "col-span-full" : ""}>
+                            <ProfileLinkGroup
+                                group={item}
                                 username={username}
                                 layoutStyle={layoutStyle}
                             />

--- a/app/[username]/ProfileLinks.tsx
+++ b/app/[username]/ProfileLinks.tsx
@@ -1,4 +1,5 @@
 import { ProfileLinkItem } from "./ProfileLinkItem";
+import { ProfileLinkGroup } from "./ProfileLinkGroup";
 import { EmptyProfileState } from "./EmptyProfileState";
 import { ProfileLinksProps } from "./types/type";
 
@@ -15,20 +16,43 @@ export function ProfileLinks({
     }
 
     const isGrid = layoutStyle === "GRID";
-    const containerClass = isGrid 
-        ? "grid grid-cols-2 md:grid-cols-4 gap-4"
-        : "space-y-3";
 
     return (
-        <div className={containerClass}>
-            {safeLinks.map((link) => (
-                <ProfileLinkItem
-                    key={link.id}
-                    link={link}
-                    username={username}
-                    layoutStyle={layoutStyle}
-                />
-            ))}
+        <div className="space-y-3">
+            {safeLinks.map((item) => {
+                if (item.isGroup) {
+                    return (
+                        <ProfileLinkGroup
+                            key={item.id}
+                            group={item}
+                            username={username}
+                            layoutStyle={layoutStyle}
+                        />
+                    );
+                }
+
+                // Top-level (ungrouped) links
+                if (isGrid) {
+                    return (
+                        <div key={item.id} className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                            <ProfileLinkItem
+                                link={item}
+                                username={username}
+                                layoutStyle={layoutStyle}
+                            />
+                        </div>
+                    );
+                }
+
+                return (
+                    <ProfileLinkItem
+                        key={item.id}
+                        link={item}
+                        username={username}
+                        layoutStyle={layoutStyle}
+                    />
+                );
+            })}
         </div>
     );
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -108,7 +108,7 @@ export default async function PublicProfile({
   }
 
   const now = new Date();
-  const activeLinks = (user.links || []).filter((link) => {
+  const activeLinks = (user.links || []).filter((link: { startDate?: Date | null; endDate?: Date | null }) => {
     if (link.startDate && new Date(link.startDate) > now) return false;
     if (link.endDate && new Date(link.endDate) < now) return false;
     return true;

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -8,6 +8,9 @@ export type Link = {
     position: number;
     clicks: number;
     isPublic: boolean;
+    isGroup: boolean;
+    parentId?: string | null;
+    children?: Link[];
     startDate?: Date | null;
     endDate?: Date | null;
     updatedAt?: Date;

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -183,12 +183,13 @@ export async function PUT(
   try {
     const updatedLink = await prisma.$transaction(async (tx) => {
         // Enforce uniqueness for the resulting route if platform is changing
-        if (data.platform) {
+        if (data.platform && data.platform !== "system_group") {
             const proposedRoute = link.alias || data.platform;
             const existingLink = await tx.link.findFirst({
                 where: {
                     userId: link.userId,
                     id: { not: link.id },
+                    isGroup: false,
                     OR: [
                         { alias: proposedRoute },
                         { platform: proposedRoute, alias: null }
@@ -284,11 +285,25 @@ export async function DELETE(
           where: { parentId: id, userId: link.userId },
         });
       } else {
-        // Ungroup: set children's parentId to null
-        await tx.link.updateMany({
-          where: { parentId: id, userId: link.userId },
-          data: { parentId: null },
+        // Ungroup: set children's parentId to null and reassign positions
+        const children = await tx.link.findMany({
+            where: { parentId: id, userId: link.userId },
+            orderBy: { position: 'asc' },
         });
+
+        const maxOrder = await tx.link.aggregate({
+            where: { userId: link.userId, parentId: null },
+            _max: { position: true },
+        });
+
+        let nextPosition = (maxOrder._max.position ?? 0) + 1;
+        
+        for (const child of children) {
+            await tx.link.update({
+                where: { id: child.id },
+                data: { parentId: null, position: nextPosition++ },
+            });
+        }
       }
       await tx.link.delete({ where: { id } });
     });

--- a/app/api/links/[id]/route.ts
+++ b/app/api/links/[id]/route.ts
@@ -44,6 +44,7 @@ export async function PUT(
   const platform = body?.platform;
   const startDate = body?.startDate;
   const endDate = body?.endDate;
+  const parentId = body?.parentId;
 
   const rawExplicitPlatform = typeof platform === "string" ? platform.trim() : null;
   const explicitPlatform = rawExplicitPlatform && Object.keys(PLATFORM_ICONS).includes(rawExplicitPlatform)
@@ -59,7 +60,31 @@ export async function PUT(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const data: { url?: string; isPublic?: boolean; label?: string; platform?: string; startDate?: Date | null; endDate?: Date | null } = {};
+  const data: { url?: string; isPublic?: boolean; label?: string; platform?: string; startDate?: Date | null; endDate?: Date | null; parentId?: string | null } = {};
+
+  // Handle parentId changes (move link into/out of a group)
+  if (parentId !== undefined) {
+    if (link.isGroup) {
+      return NextResponse.json(
+        { error: "Groups cannot be nested inside other groups" },
+        { status: 400 }
+      );
+    }
+    if (parentId === null) {
+      data.parentId = null;
+    } else {
+      const parentGroup = await prisma.link.findFirst({
+        where: { id: parentId, userId: link.userId, isGroup: true },
+      });
+      if (!parentGroup) {
+        return NextResponse.json(
+          { error: "The specified group does not exist" },
+          { status: 400 }
+        );
+      }
+      data.parentId = parentId;
+    }
+  }
 
   const activeLabel = typeof label === "string" ? label.trim() : link.label;
 
@@ -232,6 +257,15 @@ export async function DELETE(
 
   const { id } = await context.params;
 
+  // Parse body for group deletion options (may be empty for regular links)
+  let deleteChildren = false;
+  try {
+    const body = await req.json();
+    deleteChildren = body?.deleteChildren === true;
+  } catch {
+    // No body is fine for regular link deletion
+  }
+
   const link = await prisma.link.findUnique({
     where: { id },
     include: { user: true },
@@ -241,11 +275,34 @@ export async function DELETE(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  // Group deletion with transaction
+  if (link.isGroup) {
+    await prisma.$transaction(async (tx) => {
+      if (deleteChildren) {
+        // Delete all children first, then the group
+        await tx.link.deleteMany({
+          where: { parentId: id, userId: link.userId },
+        });
+      } else {
+        // Ungroup: set children's parentId to null
+        await tx.link.updateMany({
+          where: { parentId: id, userId: link.userId },
+          data: { parentId: null },
+        });
+      }
+      await tx.link.delete({ where: { id } });
+    });
+
+    return NextResponse.json({ success: true });
+  }
+
+  // Regular link deletion
   await prisma.link.delete({
     where: { id },
   });
 
   return NextResponse.json({ success: true });
 }
+
 
 

--- a/app/api/links/reorder/route.ts
+++ b/app/api/links/reorder/route.ts
@@ -49,7 +49,8 @@ export async function POST(req: Request) {
 
     // Collect ALL ids from payload
     const allPayloadIds = new Set(topIds);
-    for (const children of Object.values(groupOrders)) {
+    for (const [groupId, children] of Object.entries(groupOrders)) {
+      allPayloadIds.add(groupId);
       for (const cid of children) {
         allPayloadIds.add(cid);
       }
@@ -57,6 +58,7 @@ export async function POST(req: Request) {
 
     // Verify ownership: fetch user's link ids
     const existingLinks = await prisma.link.findMany({ where: { userId: user.id }, select: { id: true, parentId: true, isGroup: true } });
+    const existingMap = new Map(existingLinks.map((l) => [l.id, l]));
     const existingIds = new Set(existingLinks.map((l) => l.id));
 
     // REQUIRE all links in payload (no partial reorders)
@@ -68,6 +70,26 @@ export async function POST(req: Request) {
     for (const pid of allPayloadIds) {
       if (!existingIds.has(pid)) {
         return NextResponse.json({ error: "Invalid link IDs" }, { status: 403 });
+      }
+    }
+
+    // Validate groupOrders keys and child kinds
+    for (const groupId of Object.keys(groupOrders)) {
+      if (!topIds.includes(groupId)) {
+        return NextResponse.json({ error: "Groups must be at the top level" }, { status: 400 });
+      }
+      const groupLink = existingMap.get(groupId);
+      if (!groupLink || !groupLink.isGroup) {
+        return NextResponse.json({ error: "Invalid group ID" }, { status: 400 });
+      }
+    }
+    
+    for (const children of Object.values(groupOrders)) {
+      for (const cid of children) {
+        const childLink = existingMap.get(cid);
+        if (childLink?.isGroup) {
+          return NextResponse.json({ error: "Groups cannot be nested" }, { status: 400 });
+        }
       }
     }
 

--- a/app/api/links/reorder/route.ts
+++ b/app/api/links/reorder/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 
-type Body = { orderedIds?: unknown };
+type Body = { orderedIds?: unknown; groupOrders?: unknown };
 
 export async function POST(req: Request) {
   try {
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
     }
 
     const orderedIds = Array.isArray((body as Body).orderedIds)
-      ? (body as Body).orderedIds
+      ? (body as Body).orderedIds as string[]
       : undefined;
 
     if (!orderedIds || !Array.isArray(orderedIds) || orderedIds.length === 0) {
@@ -34,39 +34,76 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Too many ids" }, { status: 400 });
     }
 
-    // Convert to string ids and validate
-    const ids = orderedIds.map((id) => String(id));
+    // Parse groupOrders: { [groupId]: string[] }
+    const groupOrders: Record<string, string[]> = {};
+    if (body.groupOrders && typeof body.groupOrders === "object" && !Array.isArray(body.groupOrders)) {
+      for (const [gid, children] of Object.entries(body.groupOrders as Record<string, unknown>)) {
+        if (Array.isArray(children)) {
+          groupOrders[gid] = children.map(String);
+        }
+      }
+    }
+
+    // Convert to string ids
+    const topIds = orderedIds.map((id) => String(id));
+
+    // Collect ALL ids from payload
+    const allPayloadIds = new Set(topIds);
+    for (const children of Object.values(groupOrders)) {
+      for (const cid of children) {
+        allPayloadIds.add(cid);
+      }
+    }
 
     // Verify ownership: fetch user's link ids
-    const existingLinks = await prisma.link.findMany({ where: { userId: user.id }, select: { id: true } });
+    const existingLinks = await prisma.link.findMany({ where: { userId: user.id }, select: { id: true, parentId: true, isGroup: true } });
     const existingIds = new Set(existingLinks.map((l) => l.id));
-    
+
     // REQUIRE all links in payload (no partial reorders)
-    if (ids.length !== existingLinks.length) {
+    if (allPayloadIds.size !== existingLinks.length) {
       return NextResponse.json({ error: "Must reorder all links at once" }, { status: 400 });
     }
-    
+
     // Check all IDs belong to user
-    const invalid = ids.filter((id) => !existingIds.has(id));
-    if (invalid.length > 0) {
-      return NextResponse.json({ error: "Invalid link IDs" }, { status: 403 });
+    for (const pid of allPayloadIds) {
+      if (!existingIds.has(pid)) {
+        return NextResponse.json({ error: "Invalid link IDs" }, { status: 403 });
+      }
     }
 
-    // Check duplicates
-    const uniq = new Set(ids);
-    if (uniq.size !== ids.length) {
+    // Check for duplicates across top-level + all group children
+    if (allPayloadIds.size !== topIds.length + Object.values(groupOrders).reduce((s, c) => s + c.length, 0)) {
       return NextResponse.json({ error: "Duplicate IDs in request" }, { status: 400 });
     }
 
-    // Fetch current positions
-    const current = await prisma.link.findMany({ where: { userId: user.id }, select: { id: true, position: true } });
-    const currentMap = new Map(current.map((c) => [c.id, c.position]));
+    // Fetch current positions and parentIds
+    const current = await prisma.link.findMany({ where: { userId: user.id }, select: { id: true, position: true, parentId: true } });
+    const currentMap = new Map(current.map((c) => [c.id, { position: c.position, parentId: c.parentId }]));
 
-    type UpdatePayload = { id: string; newOrder: number };
-    // Use 1-based positions to remain consistent with creation/backfill logic
-    const updates: UpdatePayload[] = ids
-      .map((id, idx) => ({ id, newOrder: idx + 1 }))
-      .filter(({ id, newOrder }) => currentMap.get(id) !== newOrder);
+    type UpdatePayload = { id: string; newOrder: number; newParentId: string | null };
+    const updates: UpdatePayload[] = [];
+
+    // Top-level ordering (parentId = null)
+    for (let i = 0; i < topIds.length; i++) {
+      const id = topIds[i];
+      const newOrder = i + 1;
+      const cur = currentMap.get(id);
+      if (cur?.position !== newOrder || cur?.parentId !== null) {
+        updates.push({ id, newOrder, newParentId: null });
+      }
+    }
+
+    // Group children ordering
+    for (const [groupId, childIds] of Object.entries(groupOrders)) {
+      for (let i = 0; i < childIds.length; i++) {
+        const id = childIds[i];
+        const newOrder = i + 1;
+        const cur = currentMap.get(id);
+        if (cur?.position !== newOrder || cur?.parentId !== groupId) {
+          updates.push({ id, newOrder, newParentId: groupId });
+        }
+      }
+    }
 
     if (updates.length === 0) return NextResponse.json({ ok: true, changed: 0 });
 
@@ -75,7 +112,7 @@ export async function POST(req: Request) {
       updates.map((u) =>
         prisma.link.updateMany({
           where: { id: u.id, userId: user.id },
-          data: { position: u.newOrder },
+          data: { position: u.newOrder, parentId: u.newParentId },
         })
       )
     );

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -42,10 +42,79 @@ export async function POST(req: Request) {
     }
 
     const body = await req.json();
+    const isGroup = body?.isGroup === true;
+
+    const user = await prisma.user.findUnique({
+        where: { email: session.user.email },
+    });
+
+    if (!user) {
+        return NextResponse.json(
+            { error: "User not found" },
+            { status: 404 }
+        );
+    }
+
+    // --- Group creation ---
+    if (isGroup) {
+        const groupLabel = body?.label?.trim();
+        if (!groupLabel) {
+            return NextResponse.json(
+                { error: "Please enter a name for this group" },
+                { status: 400 }
+            );
+        }
+
+        try {
+            const link = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+                const maxOrder = await tx.link.aggregate({
+                    where: { userId: user.id, parentId: null },
+                    _max: { position: true },
+                    _count: { id: true },
+                });
+
+                const totalCount = await tx.link.count({ where: { userId: user.id } });
+                if (totalCount >= MAX_LINKS_PER_USER) {
+                    throw Object.assign(new Error("LINK_LIMIT_REACHED"), { code: "LINK_LIMIT_REACHED" });
+                }
+
+                return tx.link.create({
+                    data: {
+                        userId: user.id,
+                        platform: "group",
+                        label: groupLabel,
+                        url: "",
+                        isGroup: true,
+                        position: (maxOrder._max.position ?? 0) + 1,
+                    },
+                });
+            }, {
+                isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+            });
+
+            return NextResponse.json({ link: { ...link, children: [] } });
+        } catch (err: unknown) {
+            const error = err as { code?: string };
+            if (error?.code === "LINK_LIMIT_REACHED") {
+                return NextResponse.json(
+                    { error: `You can add a maximum of ${MAX_LINKS_PER_USER} links.` },
+                    { status: 400 }
+                );
+            }
+            console.error(err);
+            return NextResponse.json(
+                { error: "Something went wrong" },
+                { status: 500 }
+            );
+        }
+    }
+
+    // --- Regular link creation ---
     const rawUrl = body?.url?.trim();
     const customLabel = body?.label?.trim();
     const rawAlias = body?.alias?.trim();
     const customAlias = rawAlias ? rawAlias.toLowerCase().replace(/[^a-z0-9-]/g, "") : undefined;
+    const parentId = body?.parentId || null;
     
     if (rawAlias && !customAlias) {
         return NextResponse.json(
@@ -122,17 +191,6 @@ export async function POST(req: Request) {
         );
     }
 
-    const user = await prisma.user.findUnique({
-        where: { email: session.user.email },
-    });
-
-    if (!user) {
-        return NextResponse.json(
-            { error: "User not found" },
-            { status: 404 }
-        );
-    }
-
     const proposedRoute = customAlias || finalPlatform;
 
     try {
@@ -151,17 +209,29 @@ export async function POST(req: Request) {
                 throw Object.assign(new Error("ROUTE_ALREADY_EXISTS"), { code: "ROUTE_ALREADY_EXISTS" });
             }
 
-            const maxOrder = await tx.link.aggregate({
-                where: { userId: user.id },
-                _max: { position: true },
-                _count: { id: true },
-            });
+            // Validate parentId if provided
+            if (parentId) {
+                const parentGroup = await tx.link.findFirst({
+                    where: { id: parentId, userId: user.id, isGroup: true },
+                });
+                if (!parentGroup) {
+                    throw Object.assign(new Error("INVALID_GROUP"), { code: "INVALID_GROUP" });
+                }
+            }
+
+            const totalCount = await tx.link.count({ where: { userId: user.id } });
 
             // Enforce per-user link limit atomically inside the transaction
             // to prevent race conditions where concurrent requests bypass the check.
-            if ((maxOrder._count.id ?? 0) >= MAX_LINKS_PER_USER) {
+            if (totalCount >= MAX_LINKS_PER_USER) {
                 throw Object.assign(new Error("LINK_LIMIT_REACHED"), { code: "LINK_LIMIT_REACHED" });
             }
+
+            // Position within parent scope (top-level or inside group)
+            const maxOrder = await tx.link.aggregate({
+                where: { userId: user.id, parentId: parentId },
+                _max: { position: true },
+            });
 
             return tx.link.create({
                 data: {
@@ -171,6 +241,7 @@ export async function POST(req: Request) {
                     label: finalLabel,
                     url: finalUrl,
                     position: (maxOrder._max.position ?? 0) + 1,
+                    parentId: parentId,
                 },
             });
         }, {
@@ -185,6 +256,13 @@ export async function POST(req: Request) {
             return NextResponse.json(
                 { error: `The route '/${proposedRoute}' is already in use. Please provide a unique custom alias.` },
                 { status: 409 }
+            );
+        }
+
+        if (error?.code === "INVALID_GROUP") {
+            return NextResponse.json(
+                { error: "The specified group does not exist." },
+                { status: 400 }
             );
         }
 
@@ -221,12 +299,33 @@ export async function GET() {
     const user = await prisma.user.findUnique({ where: { email: session.user.email } });
     if (!user) return NextResponse.json({ links: [] });
 
-    const links = await prisma.link.findMany({
+    const allLinks = await prisma.link.findMany({
         where: { userId: user.id },
         orderBy: [
             { position: 'asc' },
             { createdAt: 'asc' }
         ],
+    });
+
+    // Build nested structure: top-level items with children nested under groups
+    const childrenMap = new Map<string, typeof allLinks>();
+    const topLevel: typeof allLinks = [];
+
+    for (const link of allLinks) {
+        if (link.parentId) {
+            const siblings = childrenMap.get(link.parentId) || [];
+            siblings.push(link);
+            childrenMap.set(link.parentId, siblings);
+        } else {
+            topLevel.push(link);
+        }
+    }
+
+    const links = topLevel.map(link => {
+        if (link.isGroup) {
+            return { ...link, children: childrenMap.get(link.id) || [] };
+        }
+        return link;
     });
 
     return NextResponse.json({ links });

--- a/app/api/links/route.ts
+++ b/app/api/links/route.ts
@@ -9,6 +9,7 @@ import {
     validatePlatformUrl,
 } from "@/lib/platforms";
 import { PLATFORMS } from "@/lib/constants";
+import { nestLinks } from "@/lib/linkTree";
 
 import { validateUrlBackend } from "@/lib/urlValidation";
 import { PLATFORM_ICONS } from "@/lib/platformIcons";
@@ -81,7 +82,7 @@ export async function POST(req: Request) {
                 return tx.link.create({
                     data: {
                         userId: user.id,
-                        platform: "group",
+                        platform: "system_group",
                         label: groupLabel,
                         url: "",
                         isGroup: true,
@@ -307,26 +308,7 @@ export async function GET() {
         ],
     });
 
-    // Build nested structure: top-level items with children nested under groups
-    const childrenMap = new Map<string, typeof allLinks>();
-    const topLevel: typeof allLinks = [];
-
-    for (const link of allLinks) {
-        if (link.parentId) {
-            const siblings = childrenMap.get(link.parentId) || [];
-            siblings.push(link);
-            childrenMap.set(link.parentId, siblings);
-        } else {
-            topLevel.push(link);
-        }
-    }
-
-    const links = topLevel.map(link => {
-        if (link.isGroup) {
-            return { ...link, children: childrenMap.get(link.id) || [] };
-        }
-        return link;
-    });
+    const links = nestLinks(allLinks);
 
     return NextResponse.json({ links });
 }

--- a/app/dashboard/CreateGroupDialog.tsx
+++ b/app/dashboard/CreateGroupDialog.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { getCsrfToken } from "@/lib/csrfClient";
+import toast from "react-hot-toast";
+import type { Link as ProfileLink } from "@/app/[username]/types/type";
+
+export default function CreateGroupDialog({
+    onCreated,
+    onCancel,
+}: {
+    onCreated: (group: ProfileLink) => void;
+    onCancel?: () => void;
+}) {
+    const [name, setName] = useState("");
+    const [loading, setLoading] = useState(false);
+
+    function handleCancel() {
+        setName("");
+        onCancel?.();
+    }
+
+    async function submit() {
+        const trimmed = name.trim();
+        if (!trimmed) {
+            return toast.error("Please enter a name for this group");
+        }
+
+        setLoading(true);
+        try {
+            const csrfToken = await getCsrfToken();
+            const res = await fetch("/api/links", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-csrf-token": csrfToken,
+                },
+                body: JSON.stringify({ isGroup: true, label: trimmed }),
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                return toast.error(data.error ?? "Failed to create group");
+            }
+
+            toast.success("Group created");
+            onCreated(data.link);
+            setName("");
+        } catch (err: unknown) {
+            const errorMessage = err instanceof Error ? err.message : "Failed to create group";
+            toast.error(errorMessage);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div className="rounded-lg border border-dashed border-primary/40 p-4 space-y-3 bg-primary/5">
+            <p className="text-sm font-medium">Create a new group</p>
+            <Input
+                placeholder="Group name (e.g. Socials, My Projects)"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") submit();
+                }}
+                autoFocus
+            />
+            <div className="flex gap-2">
+                <Button onClick={handleCancel} variant="outline" disabled={loading} className="flex-1">
+                    Cancel
+                </Button>
+                <Button onClick={submit} disabled={loading} className="flex-1">
+                    {loading ? "Creating…" : "Create Group"}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/app/dashboard/CreateGroupDialog.tsx
+++ b/app/dashboard/CreateGroupDialog.tsx
@@ -23,6 +23,7 @@ export default function CreateGroupDialog({
     }
 
     async function submit() {
+        if (loading) return;
         const trimmed = name.trim();
         if (!trimmed) {
             return toast.error("Please enter a name for this group");
@@ -61,11 +62,12 @@ export default function CreateGroupDialog({
         <div className="rounded-lg border border-dashed border-primary/40 p-4 space-y-3 bg-primary/5">
             <p className="text-sm font-medium">Create a new group</p>
             <Input
+                disabled={loading}
                 placeholder="Group name (e.g. Socials, My Projects)"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 onKeyDown={(e) => {
-                    if (e.key === "Enter") submit();
+                    if (e.key === "Enter" && !loading) submit();
                 }}
                 autoFocus
             />

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -40,6 +40,7 @@ export default function DashboardClient({
     const [seoDescription, setSeoDescription] = useState(initialSeoDescription || "");
     const [activeTab, setActiveTab] = useState<"links" | "appearance" | "seo">("links");
     const [showAdd, setShowAdd] = useState(false);
+    const [showGroupAdd, setShowGroupAdd] = useState(false);
     const [isEmailCaptureEnabled, setIsEmailCaptureEnabled] = useState(enableEmailCapture ?? false);
     const [isPendingEmailCapture, setIsPendingEmailCapture] = useState(false);
 
@@ -73,6 +74,11 @@ export default function DashboardClient({
         setShowAdd(false);
     }
 
+    async function addGroup(group: ProfileLink) {
+        setLinks((prev) => [...prev, { ...group, children: group.children || [] }]);
+        setShowGroupAdd(false);
+    }
+
     async function updateLink(id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null): Promise<boolean> {
         const csrfToken = await getCsrfToken();
 
@@ -99,10 +105,20 @@ export default function DashboardClient({
             const responseData = await response.json();
             toast.success("Link updated");
 
+            // Update link in nested structure
             setLinks((prev) =>
-                prev.map((l) =>
-                    l.id === id ? { ...l, ...responseData.link } : l
-                )
+                prev.map((l) => {
+                    if (l.id === id) return { ...l, ...responseData.link };
+                    if (l.isGroup && l.children) {
+                        return {
+                            ...l,
+                            children: l.children.map((c) =>
+                                c.id === id ? { ...c, ...responseData.link } : c
+                            ),
+                        };
+                    }
+                    return l;
+                })
             );
             return true;
         } catch (error) {
@@ -132,9 +148,18 @@ export default function DashboardClient({
         toast.success(isPublic ? "Link set to public" : "Link set to private");
 
         setLinks((prev) =>
-            prev.map((l) =>
-                l.id === id ? { ...l, isPublic } : l
-            )
+            prev.map((l) => {
+                if (l.id === id) return { ...l, isPublic };
+                if (l.isGroup && l.children) {
+                    return {
+                        ...l,
+                        children: l.children.map((c) =>
+                            c.id === id ? { ...c, isPublic } : c
+                        ),
+                    };
+                }
+                return l;
+            })
         );
     }
 
@@ -184,7 +209,80 @@ export default function DashboardClient({
             method: "DELETE",
         });
         toast.success("Link deleted");
-        setLinks((prev) => prev.filter((l) => l.id !== id));
+
+        // Remove from nested structure
+        setLinks((prev) =>
+            prev
+                .filter((l) => l.id !== id)
+                .map((l) => {
+                    if (l.isGroup && l.children) {
+                        return { ...l, children: l.children.filter((c) => c.id !== id) };
+                    }
+                    return l;
+                })
+        );
+    }
+
+    async function deleteGroup(groupId: string, deleteChildren: boolean) {
+        const csrfToken = await getCsrfToken();
+
+        const res = await fetch(`/api/links/${groupId}`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                "x-csrf-token": csrfToken,
+            },
+            body: JSON.stringify({ deleteChildren }),
+        });
+
+        if (!res.ok) {
+            toast.error("Failed to delete group");
+            return;
+        }
+
+        if (deleteChildren) {
+            toast.success("Group and links deleted");
+            setLinks((prev) => prev.filter((l) => l.id !== groupId));
+        } else {
+            toast.success("Group removed, links ungrouped");
+            setLinks((prev) => {
+                const group = prev.find((l) => l.id === groupId);
+                const ungroupedChildren = (group?.children || []).map((c) => ({
+                    ...c,
+                    parentId: null,
+                }));
+                const withoutGroup = prev.filter((l) => l.id !== groupId);
+                // Insert ungrouped children at the position where the group was
+                const groupIndex = prev.findIndex((l) => l.id === groupId);
+                withoutGroup.splice(groupIndex, 0, ...ungroupedChildren);
+                return withoutGroup;
+            });
+        }
+    }
+
+    async function renameGroup(groupId: string, newName: string) {
+        const csrfToken = await getCsrfToken();
+
+        const res = await fetch(`/api/links/${groupId}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "x-csrf-token": csrfToken,
+            },
+            body: JSON.stringify({ label: newName }),
+        });
+
+        if (!res.ok) {
+            toast.error("Failed to rename group");
+            return;
+        }
+
+        toast.success("Group renamed");
+        setLinks((prev) =>
+            prev.map((l) =>
+                l.id === groupId ? { ...l, label: newName } : l
+            )
+        );
     }
 
     return (
@@ -284,11 +382,16 @@ export default function DashboardClient({
                             links={links}
                             showAdd={showAdd}
                             setShowAdd={setShowAdd}
+                            showGroupAdd={showGroupAdd}
+                            setShowGroupAdd={setShowGroupAdd}
                             onExport={exportCsv}
                             onAdd={addLink}
+                            onAddGroup={addGroup}
                             onUpdate={updateLink}
                             onToggleVisibility={updateVisibility}
                             onDelete={deleteLink}
+                            onDeleteGroup={deleteGroup}
+                            onRenameGroup={renameGroup}
                             onReorder={setLinks}
                         />
                     </div>

--- a/app/dashboard/GroupItem.tsx
+++ b/app/dashboard/GroupItem.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    ChevronDown,
+    ChevronRight,
+    Pencil,
+    Trash,
+    Check,
+    X,
+    FolderOpen,
+    GripVertical,
+} from "lucide-react";
+import toast from "react-hot-toast";
+import { getCsrfToken } from "@/lib/csrfClient";
+import type { Link as ProfileLink } from "@/app/[username]/types/type";
+import { LinkItem } from "./LinkItem";
+import { SortableContext, verticalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useDroppable } from "@dnd-kit/core";
+import type { DraggableAttributes } from "@dnd-kit/core";
+import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
+import React from "react";
+
+function SortableChildWrapper({ link, children }: { link: ProfileLink; children: React.ReactNode }) {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: link.id });
+
+    const style: React.CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            data-testid="link-item"
+            data-link-id={link.id}
+        >
+            {React.isValidElement(children)
+                ? React.cloneElement(children as React.ReactElement<{ dragAttributes?: DraggableAttributes; dragListeners?: SyntheticListenerMap }>, {
+                      dragListeners: listeners,
+                      dragAttributes: attributes,
+                  })
+                : children}
+        </div>
+    );
+}
+
+export function GroupItem({
+    group,
+    username,
+    dragListeners,
+    dragAttributes,
+    onUpdate,
+    onToggleVisibility,
+    onDeleteLink,
+    onDeleteGroup,
+    onRenameGroup,
+}: {
+    group: ProfileLink;
+    username: string;
+    dragListeners?: SyntheticListenerMap;
+    dragAttributes?: DraggableAttributes;
+    onUpdate: (id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null) => Promise<boolean>;
+    onToggleVisibility: (id: string, isPublic: boolean) => Promise<void>;
+    onDeleteLink: (id: string) => Promise<void>;
+    onDeleteGroup: (groupId: string, deleteChildren: boolean) => Promise<void>;
+    onRenameGroup: (groupId: string, newName: string) => Promise<void>;
+}) {
+    const [expanded, setExpanded] = useState(true);
+    const [editing, setEditing] = useState(false);
+    const [newName, setNewName] = useState(group.label);
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+    const children = group.children || [];
+
+    // Make the group body a droppable area
+    const { setNodeRef: setDroppableRef, isOver } = useDroppable({
+        id: `group-drop-${group.id}`,
+        data: { type: "group", groupId: group.id },
+    });
+
+    async function handleRename() {
+        const trimmed = newName.trim();
+        if (!trimmed) {
+            return toast.error("Group name cannot be empty");
+        }
+        await onRenameGroup(group.id, trimmed);
+        setEditing(false);
+    }
+
+    return (
+        <div className={`rounded-lg border-2 transition-colors ${isOver ? "border-primary bg-primary/5" : "border-muted"}`}>
+            {/* Group header */}
+            <div className="flex items-center gap-2 p-3 bg-muted/30 rounded-t-lg">
+                <div
+                    {...dragListeners}
+                    {...dragAttributes}
+                    role="button"
+                    aria-label="Drag to reorder group"
+                    tabIndex={0}
+                    className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring rounded p-1"
+                >
+                    <GripVertical className="h-4 w-4" />
+                </div>
+
+                <button
+                    onClick={() => setExpanded((v) => !v)}
+                    className="flex items-center gap-2 flex-1 text-left"
+                    aria-label={expanded ? "Collapse group" : "Expand group"}
+                >
+                    {expanded ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    <FolderOpen className="h-4 w-4 text-primary" />
+
+                    {editing ? (
+                        <Input
+                            value={newName}
+                            onChange={(e) => setNewName(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleRename();
+                                if (e.key === "Escape") {
+                                    setNewName(group.label);
+                                    setEditing(false);
+                                }
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                            className="h-7 text-sm max-w-[200px]"
+                            autoFocus
+                        />
+                    ) : (
+                        <span className="font-medium text-sm">{group.label}</span>
+                    )}
+
+                    <span className="text-xs text-muted-foreground ml-1">
+                        ({children.length} {children.length === 1 ? "link" : "links"})
+                    </span>
+                </button>
+
+                <div className="flex gap-1">
+                    {editing ? (
+                        <>
+                            <Button size="icon" variant="ghost" onClick={handleRename} className="h-7 w-7">
+                                <Check className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => {
+                                    setNewName(group.label);
+                                    setEditing(false);
+                                }}
+                                className="h-7 w-7"
+                            >
+                                <X className="h-3.5 w-3.5" />
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => setEditing(true)}
+                                className="h-7 w-7"
+                                aria-label="Rename group"
+                            >
+                                <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => setShowDeleteConfirm(true)}
+                                className="h-7 w-7 text-destructive hover:text-destructive"
+                                aria-label="Delete group"
+                            >
+                                <Trash className="h-3.5 w-3.5" />
+                            </Button>
+                        </>
+                    )}
+                </div>
+            </div>
+
+            {/* Delete confirmation */}
+            {showDeleteConfirm && (
+                <div className="p-3 bg-destructive/5 border-t flex flex-col gap-2">
+                    <p className="text-sm font-medium">Delete this group?</p>
+                    <p className="text-xs text-muted-foreground">
+                        Choose what happens to the {children.length} link{children.length !== 1 ? "s" : ""} inside:
+                    </p>
+                    <div className="flex gap-2">
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                                onDeleteGroup(group.id, false);
+                                setShowDeleteConfirm(false);
+                            }}
+                        >
+                            Ungroup links
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => {
+                                onDeleteGroup(group.id, true);
+                                setShowDeleteConfirm(false);
+                            }}
+                        >
+                            Delete all
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setShowDeleteConfirm(false)}
+                        >
+                            Cancel
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {/* Group children */}
+            {expanded && (
+                <div
+                    ref={setDroppableRef}
+                    className={`p-3 space-y-3 min-h-[48px] transition-colors rounded-b-lg ${
+                        isOver ? "bg-primary/5" : ""
+                    } ${children.length === 0 ? "flex items-center justify-center" : ""}`}
+                >
+                    {children.length === 0 ? (
+                        <p className="text-xs text-muted-foreground italic">
+                            Drag links here to add them to this group
+                        </p>
+                    ) : (
+                        <SortableContext items={children.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+                            {children.map((link) => (
+                                <SortableChildWrapper key={link.id} link={link}>
+                                    <LinkItem
+                                        link={link}
+                                        username={username}
+                                        onUpdate={onUpdate}
+                                        onToggleVisibility={onToggleVisibility}
+                                        onDelete={onDeleteLink}
+                                    />
+                                </SortableChildWrapper>
+                            ))}
+                        </SortableContext>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/dashboard/GroupItem.tsx
+++ b/app/dashboard/GroupItem.tsx
@@ -107,17 +107,19 @@ export function GroupItem({
                     <GripVertical className="h-4 w-4" />
                 </div>
 
-                <button
-                    onClick={() => setExpanded((v) => !v)}
-                    className="flex items-center gap-2 flex-1 text-left"
-                    aria-label={expanded ? "Collapse group" : "Expand group"}
-                >
-                    {expanded ? (
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                    )}
-                    <FolderOpen className="h-4 w-4 text-primary" />
+                <div className="flex items-center gap-2 flex-1">
+                    <button
+                        onClick={() => setExpanded((v) => !v)}
+                        className="flex items-center gap-2"
+                        aria-label={expanded ? "Collapse group" : "Expand group"}
+                    >
+                        {expanded ? (
+                            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <FolderOpen className="h-4 w-4 text-primary" />
+                    </button>
 
                     {editing ? (
                         <Input
@@ -135,13 +137,17 @@ export function GroupItem({
                             autoFocus
                         />
                     ) : (
-                        <span className="font-medium text-sm">{group.label}</span>
+                        <button
+                            onClick={() => setExpanded((v) => !v)}
+                            className="flex items-center text-left"
+                        >
+                            <span className="font-medium text-sm">{group.label}</span>
+                            <span className="text-xs text-muted-foreground ml-1">
+                                ({children.length} {children.length === 1 ? "link" : "links"})
+                            </span>
+                        </button>
                     )}
-
-                    <span className="text-xs text-muted-foreground ml-1">
-                        ({children.length} {children.length === 1 ? "link" : "links"})
-                    </span>
-                </button>
+                </div>
 
                 <div className="flex gap-1">
                     {editing ? (

--- a/app/dashboard/LinksSection.tsx
+++ b/app/dashboard/LinksSection.tsx
@@ -2,15 +2,17 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus, FolderPlus } from "lucide-react";
 import { EmptyLinksState } from "./EmptyLinksState";
 import { LinkItem } from "./LinkItem";
+import { GroupItem } from "./GroupItem";
 import AddLinkBox from "./AddLinkBox";
+import CreateGroupDialog from "./CreateGroupDialog";
 import type { Link as ProfileLink } from "@/app/[username]/types/type";
 import React from "react";
 
 // dnd-kit
-import { DndContext, DragEndEvent, DraggableAttributes } from "@dnd-kit/core";
+import { DndContext, DragEndEvent, DragOverEvent, DraggableAttributes, DragOverlay, DragStartEvent, pointerWithin } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import {
     SortableContext,
@@ -26,11 +28,16 @@ type LinksSectionProps = {
     links: ProfileLink[];
     showAdd: boolean;
     setShowAdd: React.Dispatch<React.SetStateAction<boolean>>;
+    showGroupAdd: boolean;
+    setShowGroupAdd: React.Dispatch<React.SetStateAction<boolean>>;
     onExport: () => void;
     onAdd: (link: ProfileLink) => void | Promise<void>;
+    onAddGroup: (group: ProfileLink) => void | Promise<void>;
     onUpdate: (id: string, url: string, label?: string, platform?: string, startDate?: Date | null, endDate?: Date | null) => Promise<boolean>;
     onToggleVisibility: (id: string, isPublic: boolean) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
+    onDeleteGroup: (groupId: string, deleteChildren: boolean) => Promise<void>;
+    onRenameGroup: (groupId: string, newName: string) => Promise<void>;
     onReorder: (links: ProfileLink[]) => void;
 };
 
@@ -59,23 +66,85 @@ function SortableLinkWrapper({ link, children }: { link: ProfileLink; children: 
     );
 }
 
+function SortableGroupWrapper({ group, children }: { group: ProfileLink; children: React.ReactNode }) {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: group.id });
+
+    const style: React.CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            data-testid="group-item"
+            data-group-id={group.id}
+        >
+            {React.isValidElement(children)
+                ? React.cloneElement(children as React.ReactElement<{ dragAttributes?: DraggableAttributes; dragListeners?: SyntheticListenerMap }>, {
+                      dragListeners: listeners,
+                      dragAttributes: attributes,
+                  })
+                : children}
+        </div>
+    );
+}
+
+/**
+ * Flatten the nested link structure to get all IDs for reorder payload
+ */
+function buildReorderPayload(links: ProfileLink[]) {
+    const orderedIds: string[] = [];
+    const groupOrders: Record<string, string[]> = {};
+
+    for (const item of links) {
+        orderedIds.push(item.id);
+        if (item.isGroup && item.children) {
+            groupOrders[item.id] = item.children.map((c) => c.id);
+        }
+    }
+
+    return { orderedIds, groupOrders };
+}
+
+/**
+ * Find a link by ID in the nested structure
+ */
+function findLinkById(links: ProfileLink[], id: string): { link: ProfileLink; parentId: string | null } | null {
+    for (const item of links) {
+        if (item.id === id) return { link: item, parentId: null };
+        if (item.isGroup && item.children) {
+            for (const child of item.children) {
+                if (child.id === id) return { link: child, parentId: item.id };
+            }
+        }
+    }
+    return null;
+}
+
 export function LinksSection({
     username,
     links,
     showAdd,
     setShowAdd,
+    showGroupAdd,
+    setShowGroupAdd,
     onExport,
     onAdd,
+    onAddGroup,
     onUpdate,
     onToggleVisibility,
     onDelete,
+    onDeleteGroup,
+    onRenameGroup,
     onReorder,
 }: LinksSectionProps) {
     const [localLinks, setLocalLinks] = React.useState<ProfileLink[]>(links);
     const localLinksRef = React.useRef(localLinks);
     const [isSaving, setIsSaving] = React.useState(false);
+    const [activeId, setActiveId] = React.useState<string | null>(null);
 
-    // Actually, let me just keep it simple:
     const updateLocalLinks = React.useCallback((newLinks: ProfileLink[] | ((prev: ProfileLink[]) => ProfileLink[])) => {
         setLocalLinks(prev => {
             const next = typeof newLinks === "function" ? newLinks(prev) : newLinks;
@@ -84,15 +153,11 @@ export function LinksSection({
         });
     }, []);
 
-    // Track optimistic reorder state to avoid clobbering local optimistic changes
     const isReorderingRef = React.useRef(false);
-
-    // Serialize concurrent saves
     const inFlightRef = React.useRef(false);
-    const pendingOrderedIdsRef = React.useRef<string[] | null>(null);
+    const pendingPayloadRef = React.useRef<{ orderedIds: string[]; groupOrders: Record<string, string[]> } | null>(null);
 
     React.useEffect(() => {
-        // Only sync from props if not actively reordering
         if (!isReorderingRef.current) {
             if (JSON.stringify(links) !== JSON.stringify(localLinksRef.current)) {
                 localLinksRef.current = links;
@@ -102,32 +167,29 @@ export function LinksSection({
     }, [links]);
 
     const saveOrder = React.useCallback(async () => {
-        // Ensure only one in-flight request at a time and properly handle state
         if (inFlightRef.current) return;
         inFlightRef.current = true;
         isReorderingRef.current = true;
 
-        while (pendingOrderedIdsRef.current) {
-            const ids = pendingOrderedIdsRef.current;
-            pendingOrderedIdsRef.current = null;
+        while (pendingPayloadRef.current) {
+            const payload = pendingPayloadRef.current;
+            pendingPayloadRef.current = null;
             setIsSaving(true);
-            
+
             try {
                 const res = await fetch("/api/links/reorder", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ orderedIds: ids }),
+                    body: JSON.stringify(payload),
                 });
 
                 if (!res.ok) {
-                    // On error, re-fetch authoritative order and apply locally
                     const refresh = await fetch("/api/links");
                     const data = await refresh.json();
                     updateLocalLinks(data.links || []);
                     onReorder(data.links || []);
                 }
             } catch {
-                // Network error: refetch to reconcile
                 try {
                     const refresh = await fetch("/api/links");
                     const data = await refresh.json();
@@ -138,7 +200,7 @@ export function LinksSection({
                 }
             }
         }
-        
+
         inFlightRef.current = false;
         setIsSaving(false);
         isReorderingRef.current = false;
@@ -146,25 +208,108 @@ export function LinksSection({
 
     const debouncedSave = useDebounce(() => saveOrder(), 500);
 
+    const triggerReorder = React.useCallback((newList: ProfileLink[]) => {
+        updateLocalLinks(newList);
+        onReorder(newList);
+        isReorderingRef.current = true;
+        pendingPayloadRef.current = buildReorderPayload(newList);
+        debouncedSave();
+    }, [debouncedSave, onReorder, updateLocalLinks]);
+
+    const handleDragStart = React.useCallback((event: DragStartEvent) => {
+        setActiveId(String(event.active.id));
+    }, []);
+
+    const handleDragOver = React.useCallback((event: DragOverEvent) => {
+        const { active, over } = event;
+        if (!over) return;
+
+        const activeIdStr = String(active.id);
+        const overIdStr = String(over.id);
+
+        // Check if dragging over a group drop zone
+        if (overIdStr.startsWith("group-drop-")) {
+            const targetGroupId = overIdStr.replace("group-drop-", "");
+            const found = findLinkById(localLinks, activeIdStr);
+            if (!found) return;
+            
+            // Don't allow groups into groups
+            if (found.link.isGroup) return;
+            
+            // Already in this group
+            if (found.parentId === targetGroupId) return;
+
+            // Move link into group
+            const newList = localLinks.map(item => {
+                if (item.id === activeIdStr) return null; // Remove from top level
+                if (item.isGroup && item.children) {
+                    return {
+                        ...item,
+                        children: item.id === targetGroupId
+                            ? [...item.children.filter(c => c.id !== activeIdStr), { ...found.link, parentId: targetGroupId }]
+                            : item.children.filter(c => c.id !== activeIdStr),
+                    };
+                }
+                return item;
+            }).filter(Boolean) as ProfileLink[];
+
+            updateLocalLinks(newList);
+        }
+    }, [localLinks, updateLocalLinks]);
+
     const handleDragEnd = React.useCallback(
         (event: DragEndEvent) => {
+            setActiveId(null);
             const { active, over } = event;
             if (!over || active.id === over.id) return;
 
-            const oldIndex = localLinks.findIndex((l) => l.id === String(active.id));
-            const newIndex = localLinks.findIndex((l) => l.id === String(over.id));
-            if (oldIndex === -1 || newIndex === -1) return;
+            const activeIdStr = String(active.id);
+            const overIdStr = String(over.id);
 
-            const newList = arrayMove(localLinks, oldIndex, newIndex);
-            updateLocalLinks(newList);
-            onReorder(newList); // Synchronize parent state immediately
-            // Queue the latest order and kick off the save loop
-            isReorderingRef.current = true;
-            pendingOrderedIdsRef.current = newList.map((l) => l.id);
-            debouncedSave();
+            // If dropping over a group drop zone, the move was handled in handleDragOver
+            if (overIdStr.startsWith("group-drop-")) {
+                triggerReorder(localLinks);
+                return;
+            }
+
+            // Check if both items are at the same level
+            const activeFound = findLinkById(localLinks, activeIdStr);
+            const overFound = findLinkById(localLinks, overIdStr);
+            if (!activeFound || !overFound) return;
+
+            if (activeFound.parentId === overFound.parentId) {
+                // Same level reorder
+                if (activeFound.parentId === null) {
+                    // Top level
+                    const oldIndex = localLinks.findIndex(l => l.id === activeIdStr);
+                    const newIndex = localLinks.findIndex(l => l.id === overIdStr);
+                    if (oldIndex === -1 || newIndex === -1) return;
+                    const newList = arrayMove(localLinks, oldIndex, newIndex);
+                    triggerReorder(newList);
+                } else {
+                    // Within a group
+                    const newList = localLinks.map(item => {
+                        if (item.id === activeFound.parentId && item.children) {
+                            const oldIndex = item.children.findIndex(c => c.id === activeIdStr);
+                            const newIndex = item.children.findIndex(c => c.id === overIdStr);
+                            if (oldIndex === -1 || newIndex === -1) return item;
+                            return { ...item, children: arrayMove(item.children, oldIndex, newIndex) };
+                        }
+                        return item;
+                    });
+                    triggerReorder(newList);
+                }
+            } else {
+                // Moving between levels — link is being moved out of a group to top level
+                // or between groups. The drag-over handler already handled this.
+                triggerReorder(localLinks);
+            }
         },
-        [localLinks, debouncedSave, onReorder, updateLocalLinks]
+        [localLinks, triggerReorder]
     );
+
+    // Get all sortable IDs (top-level + all children for nested contexts)
+    const topLevelIds = localLinks.map(l => l.id);
 
     return (
         <Card>
@@ -174,7 +319,11 @@ export function LinksSection({
                     <Button size="sm" variant="outline" onClick={onExport}>
                         Export CSV
                     </Button>
-                    <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
+                    <Button size="sm" variant="outline" onClick={() => { setShowGroupAdd((v) => !v); setShowAdd(false); }}>
+                        <FolderPlus className="mr-2 h-4 w-4" />
+                        Add Group
+                    </Button>
+                    <Button size="sm" onClick={() => { setShowAdd((v) => !v); setShowGroupAdd(false); }}>
                         <Plus className="mr-2 h-4 w-4" />
                         Add Link
                     </Button>
@@ -183,27 +332,61 @@ export function LinksSection({
 
             <CardContent className="space-y-4">
                 {showAdd && <AddLinkBox onAdded={onAdd} onCancel={() => setShowAdd(false)} />}
+                {showGroupAdd && <CreateGroupDialog onCreated={onAddGroup} onCancel={() => setShowGroupAdd(false)} />}
 
-                {localLinks.length === 0 && !showAdd && (
+                {localLinks.length === 0 && !showAdd && !showGroupAdd && (
                     <EmptyLinksState onAdd={() => setShowAdd(true)} />
                 )}
 
-                <DndContext onDragEnd={handleDragEnd}>
-                    <SortableContext items={localLinks.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+                <DndContext
+                    onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
+                    onDragEnd={handleDragEnd}
+                    collisionDetection={pointerWithin}
+                >
+                    <SortableContext items={topLevelIds} strategy={verticalListSortingStrategy}>
                         <div className="space-y-4">
-                            {localLinks.map((link) => (
-                                <SortableLinkWrapper key={link.id} link={link}>
-                                    <LinkItem
-                                        link={link}
-                                        username={username}
-                                        onUpdate={onUpdate}
-                                        onToggleVisibility={onToggleVisibility}
-                                        onDelete={onDelete}
-                                    />
-                                </SortableLinkWrapper>
-                            ))}
+                            {localLinks.map((item) => {
+                                if (item.isGroup) {
+                                    return (
+                                        <SortableGroupWrapper key={item.id} group={item}>
+                                            <GroupItem
+                                                group={item}
+                                                username={username}
+                                                onUpdate={onUpdate}
+                                                onToggleVisibility={onToggleVisibility}
+                                                onDeleteLink={onDelete}
+                                                onDeleteGroup={onDeleteGroup}
+                                                onRenameGroup={onRenameGroup}
+                                            />
+                                        </SortableGroupWrapper>
+                                    );
+                                }
+                                return (
+                                    <SortableLinkWrapper key={item.id} link={item}>
+                                        <LinkItem
+                                            link={item}
+                                            username={username}
+                                            onUpdate={onUpdate}
+                                            onToggleVisibility={onToggleVisibility}
+                                            onDelete={onDelete}
+                                        />
+                                    </SortableLinkWrapper>
+                                );
+                            })}
                         </div>
                     </SortableContext>
+
+                    <DragOverlay>
+                        {activeId ? (
+                            <div className="opacity-70 pointer-events-none bg-background rounded-md border p-4 shadow-lg">
+                                {(() => {
+                                    const found = findLinkById(localLinks, activeId);
+                                    return found ? <span className="font-medium text-sm">{found.link.label || found.link.platform}</span> : null;
+                                })()}
+                            </div>
+                        ) : null}
+                    </DragOverlay>
                 </DndContext>
 
                 {isSaving && <p className="mt-4 text-sm text-gray-500">Saving order...</p>}

--- a/app/dashboard/LinksSection.tsx
+++ b/app/dashboard/LinksSection.tsx
@@ -227,33 +227,78 @@ export function LinksSection({
         const activeIdStr = String(active.id);
         const overIdStr = String(over.id);
 
-        // Check if dragging over a group drop zone
+        const activeFound = findLinkById(localLinks, activeIdStr);
+        if (!activeFound) return;
+        if (activeFound.link.isGroup) return; // Don't allow groups into groups
+
+        let targetParentId: string | null = null;
         if (overIdStr.startsWith("group-drop-")) {
-            const targetGroupId = overIdStr.replace("group-drop-", "");
-            const found = findLinkById(localLinks, activeIdStr);
-            if (!found) return;
-            
-            // Don't allow groups into groups
-            if (found.link.isGroup) return;
-            
-            // Already in this group
-            if (found.parentId === targetGroupId) return;
+            targetParentId = overIdStr.replace("group-drop-", "");
+        } else {
+            const overFound = findLinkById(localLinks, overIdStr);
+            if (overFound) {
+                targetParentId = overFound.parentId;
+            }
+        }
 
-            // Move link into group
-            const newList = localLinks.map(item => {
-                if (item.id === activeIdStr) return null; // Remove from top level
-                if (item.isGroup && item.children) {
-                    return {
-                        ...item,
-                        children: item.id === targetGroupId
-                            ? [...item.children.filter(c => c.id !== activeIdStr), { ...found.link, parentId: targetGroupId }]
-                            : item.children.filter(c => c.id !== activeIdStr),
-                    };
+        if (activeFound.parentId !== targetParentId) {
+            const newLinks = [...localLinks];
+            
+            // Remove from old location
+            let movingLink: ProfileLink | null = null;
+            if (activeFound.parentId === null) {
+                const idx = newLinks.findIndex(l => l.id === activeIdStr);
+                if (idx !== -1) {
+                    movingLink = newLinks[idx];
+                    newLinks.splice(idx, 1);
                 }
-                return item;
-            }).filter(Boolean) as ProfileLink[];
+            } else {
+                const groupIdx = newLinks.findIndex(l => l.id === activeFound.parentId);
+                if (groupIdx !== -1 && newLinks[groupIdx].children) {
+                    const group = { ...newLinks[groupIdx] };
+                    const children = [...(group.children || [])];
+                    const childIdx = children.findIndex(c => c.id === activeIdStr);
+                    if (childIdx !== -1) {
+                        movingLink = { ...children[childIdx] };
+                        children.splice(childIdx, 1);
+                        group.children = children;
+                        newLinks[groupIdx] = group;
+                    }
+                }
+            }
 
-            updateLocalLinks(newList);
+            if (!movingLink) return;
+            movingLink.parentId = targetParentId;
+
+            // Insert into new location
+            if (targetParentId === null) {
+                const overIdx = newLinks.findIndex(l => l.id === overIdStr);
+                if (overIdx !== -1) {
+                    newLinks.splice(overIdx, 0, movingLink);
+                } else {
+                    newLinks.push(movingLink);
+                }
+            } else {
+                const groupIdx = newLinks.findIndex(l => l.id === targetParentId);
+                if (groupIdx !== -1) {
+                    const group = { ...newLinks[groupIdx] };
+                    const children = [...(group.children || [])];
+                    
+                    if (overIdStr.startsWith("group-drop-")) {
+                        children.push(movingLink);
+                    } else {
+                        const overIdx = children.findIndex(c => c.id === overIdStr);
+                        if (overIdx !== -1) {
+                            children.splice(overIdx, 0, movingLink);
+                        } else {
+                            children.push(movingLink);
+                        }
+                    }
+                    group.children = children;
+                    newLinks[groupIdx] = group;
+                }
+            }
+            updateLocalLinks(newLinks);
         }
     }, [localLinks, updateLocalLinks]);
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,33 @@ import prisma from "@/lib/prisma";
 import DashboardClient from "./DashboardClient";
 import CreateLinkId from "./CreateLinkId";
 import QRCode from "./qrcode";
+import type { Link } from "@prisma/client";
+
+/**
+ * Nest flat links array into a grouped structure.
+ * Groups (isGroup=true) get a `children` array.
+ */
+function nestLinks(links: Link[]) {
+    const childrenMap = new Map<string, Link[]>();
+    const topLevel: Link[] = [];
+
+    for (const link of links) {
+        if (link.parentId) {
+            const siblings = childrenMap.get(link.parentId) || [];
+            siblings.push(link);
+            childrenMap.set(link.parentId, siblings);
+        } else {
+            topLevel.push(link);
+        }
+    }
+
+    return topLevel.map(link => {
+        if (link.isGroup) {
+            return { ...link, children: childrenMap.get(link.id) || [] };
+        }
+        return link;
+    });
+}
 
 export default async function DashboardPage() {
     const session = await getServerSession(authOptions);
@@ -20,10 +47,12 @@ export default async function DashboardPage() {
 
     if (!user?.username) return <CreateLinkId />;
 
+    const nestedLinks = nestLinks(user.links);
+
     return (
         <DashboardClient
             username={user.username}
-            initialLinks={user.links}
+            initialLinks={nestedLinks}
             initialTheme={user.theme}
             initialLayout={user.layoutStyle}
             initialSeoTitle={user.seoTitle || ""}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,31 +7,7 @@ import CreateLinkId from "./CreateLinkId";
 import QRCode from "./qrcode";
 import type { Link } from "@prisma/client";
 
-/**
- * Nest flat links array into a grouped structure.
- * Groups (isGroup=true) get a `children` array.
- */
-function nestLinks(links: Link[]) {
-    const childrenMap = new Map<string, Link[]>();
-    const topLevel: Link[] = [];
-
-    for (const link of links) {
-        if (link.parentId) {
-            const siblings = childrenMap.get(link.parentId) || [];
-            siblings.push(link);
-            childrenMap.set(link.parentId, siblings);
-        } else {
-            topLevel.push(link);
-        }
-    }
-
-    return topLevel.map(link => {
-        if (link.isGroup) {
-            return { ...link, children: childrenMap.get(link.id) || [] };
-        }
-        return link;
-    });
-}
+import { nestLinks } from "@/lib/linkTree";
 
 export default async function DashboardPage() {
     const session = await getServerSession(authOptions);

--- a/lib/linkTree.ts
+++ b/lib/linkTree.ts
@@ -1,0 +1,28 @@
+import type { Link } from "@prisma/client";
+
+/**
+ * Transforms a flat list of links into a nested structure.
+ * Groups (isGroup=true) get a `children` array of their child links.
+ * Top-level links (parentId=null) without isGroup remain unchanged.
+ */
+export function nestLinks(links: Link[]): (Link & { children?: Link[] })[] {
+    const childrenMap = new Map<string, Link[]>();
+    const topLevel: Link[] = [];
+
+    for (const link of links) {
+        if (link.parentId) {
+            const siblings = childrenMap.get(link.parentId) || [];
+            siblings.push(link);
+            childrenMap.set(link.parentId, siblings);
+        } else {
+            topLevel.push(link);
+        }
+    }
+
+    return topLevel.map(link => {
+        if (link.isGroup) {
+            return { ...link, children: childrenMap.get(link.id) || [] };
+        }
+        return link;
+    });
+}

--- a/lib/userLookup.ts
+++ b/lib/userLookup.ts
@@ -2,32 +2,7 @@ import prisma from "@/lib/prisma";
 import { unstable_cache } from "next/cache";
 import type { Link } from "@prisma/client";
 
-/**
- * Transforms a flat list of links into a nested structure.
- * Groups (isGroup=true) get a `children` array of their child links.
- * Top-level links (parentId=null) without isGroup remain unchanged.
- */
-function nestLinks(links: Link[]): (Link & { children?: Link[] })[] {
-    const childrenMap = new Map<string, Link[]>();
-    const topLevel: Link[] = [];
-
-    for (const link of links) {
-        if (link.parentId) {
-            const siblings = childrenMap.get(link.parentId) || [];
-            siblings.push(link);
-            childrenMap.set(link.parentId, siblings);
-        } else {
-            topLevel.push(link);
-        }
-    }
-
-    return topLevel.map(link => {
-        if (link.isGroup) {
-            return { ...link, children: childrenMap.get(link.id) || [] };
-        }
-        return link;
-    });
-}
+import { nestLinks } from "./linkTree";
 
 
 export const resolveUserByUsername = unstable_cache(

--- a/lib/userLookup.ts
+++ b/lib/userLookup.ts
@@ -1,5 +1,34 @@
 import prisma from "@/lib/prisma";
 import { unstable_cache } from "next/cache";
+import type { Link } from "@prisma/client";
+
+/**
+ * Transforms a flat list of links into a nested structure.
+ * Groups (isGroup=true) get a `children` array of their child links.
+ * Top-level links (parentId=null) without isGroup remain unchanged.
+ */
+function nestLinks(links: Link[]): (Link & { children?: Link[] })[] {
+    const childrenMap = new Map<string, Link[]>();
+    const topLevel: Link[] = [];
+
+    for (const link of links) {
+        if (link.parentId) {
+            const siblings = childrenMap.get(link.parentId) || [];
+            siblings.push(link);
+            childrenMap.set(link.parentId, siblings);
+        } else {
+            topLevel.push(link);
+        }
+    }
+
+    return topLevel.map(link => {
+        if (link.isGroup) {
+            return { ...link, children: childrenMap.get(link.id) || [] };
+        }
+        return link;
+    });
+}
+
 
 export const resolveUserByUsername = unstable_cache(
     async (username: string) => {
@@ -9,7 +38,7 @@ export const resolveUserByUsername = unstable_cache(
         });
 
         if (exactUser) {
-            return { user: exactUser, canonicalUsername: exactUser.username ?? username };
+            return { user: { ...exactUser, links: nestLinks(exactUser.links) }, canonicalUsername: exactUser.username ?? username };
         }
 
         const alias = await prisma.userAlias.findUnique({
@@ -29,7 +58,7 @@ export const resolveUserByUsername = unstable_cache(
             return null;
         }
 
-        return { user, canonicalUsername: user.username ?? username };
+        return { user: { ...user, links: nestLinks(user.links) }, canonicalUsername: user.username ?? username };
     },
     ["resolveUserByUsername"],
     { revalidate: 60, tags: ["public-profile"] }

--- a/prisma/migrations/20260801_add_link_groups/migration.sql
+++ b/prisma/migrations/20260801_add_link_groups/migration.sql
@@ -2,8 +2,5 @@
 ALTER TABLE "Link" ADD COLUMN "isGroup" BOOLEAN NOT NULL DEFAULT false,
 ADD COLUMN "parentId" TEXT;
 
--- CreateIndex
-CREATE INDEX "Link_parentId_idx" ON "Link"("parentId");
-
--- AddForeignKey
-ALTER TABLE "Link" ADD CONSTRAINT "Link_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Link"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+-- AddForeignKey (Not Valid initially)
+ALTER TABLE "Link" ADD CONSTRAINT "Link_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Link"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;

--- a/prisma/migrations/20260801_add_link_groups/migration.sql
+++ b/prisma/migrations/20260801_add_link_groups/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "Link" ADD COLUMN "isGroup" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "parentId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Link_parentId_idx" ON "Link"("parentId");
+
+-- AddForeignKey
+ALTER TABLE "Link" ADD CONSTRAINT "Link_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Link"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260801_add_link_groups_index/migration.sql
+++ b/prisma/migrations/20260801_add_link_groups_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "Link_parentId_idx" ON "Link"("parentId");

--- a/prisma/migrations/20260801_add_link_groups_validate/migration.sql
+++ b/prisma/migrations/20260801_add_link_groups_validate/migration.sql
@@ -1,0 +1,2 @@
+-- Validate constraint
+ALTER TABLE "Link" VALIDATE CONSTRAINT "Link_parentId_fkey";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,16 +76,21 @@ model Link {
   position  Int      @default(0)
   clicks    Int      @default(0)
   isPublic  Boolean  @default(true)
+  isGroup   Boolean  @default(false)
+  parentId  String?
   startDate DateTime?
   endDate   DateTime?
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent    Link?    @relation("LinkGroup", fields: [parentId], references: [id], onDelete: SetNull)
+  children  Link[]   @relation("LinkGroup")
   clickEvents ClickEvent[]
   dailyAnalytics DailyLinkAnalytics[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   @@index([userId])
   @@index([platform])
+  @@index([parentId])
 }
 
 model ClickEvent {


### PR DESCRIPTION
## Description
Resolves #554.

This PR introduces the ability for users to organize their growing list of links into categories/collapsible folders (up to 1 level deep). This helps declutter profiles with many links, improving the overall organization and user experience for both the profile owner and visitors.

## Key Changes
- **Database Schema**: Updated the Prisma `Link` model to include an `isGroup` flag and a self-referential `parentId` relationship.
- **Dashboard UI**: 
  - Added a new "Add Group" button.
  - Implemented nested drag-and-drop using `@dnd-kit`, allowing users to drag links directly into and out of folders.
  - Added inline renaming and group deletion (with options to either delete all children or just ungroup them).
- **Public Profile**: Added the `ProfileLinkGroup` component to render folders as sleek, collapsible accordions using `framer-motion` for smooth animations.
- **API & Data Fetching**: Updated the backend routes to handle nested parent/child relationships efficiently and securely via database transactions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added link groups for organizing related profile links.
  * Create, rename, expand, collapse, and delete groups from the dashboard.
  * Move links into, between, or out of groups with drag-and-drop.
  * Choose whether to delete grouped links or keep them when removing a group.
  * Grouped links display as expandable sections with responsive layouts on public profiles.
* **Bug Fixes**
  * Improved validation for group membership, ordering, and active link visibility.
  * Prevented unsupported nested groups and invalid group assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->