### PR TITLE
fix(test): make npm test pass on a fresh clone (#568)

### DIFF
--- a/app/api/user/layout/route.test.ts
+++ b/app/api/user/layout/route.test.ts
@@ -1,78 +1,75 @@
+import assert from "node:assert/strict";
+import { mock, test, before } from "node:test";
 import { NextRequest } from "next/server";
-import { PATCH } from "./route";
-import { getServerSession } from "next-auth";
-import prisma from "@/lib/prisma";
 
-jest.mock("next-auth", () => ({
-    getServerSession: jest.fn(),
-}));
+// ── Mutable state shared across mock closures ─────────────────────────────────
+let mockSession: unknown = null;
+let capturedUpdateArgs: unknown = null;
+let updateResult: unknown = { layoutStyle: "GRID" };
 
-jest.mock("@/lib/prisma", () => ({
-    __esModule: true,
-    default: {
-        user: {
-            update: jest.fn(),
-        },
+// ── Register mocks synchronously BEFORE the route is imported ──────────────────
+// (importing the route directly pulls in @/lib/auth, which uses `server-only`.)
+mock.module("next-auth", {
+    namedExports: {
+        getServerSession: () => Promise.resolve(mockSession),
     },
-}));
+});
 
-describe("PATCH /api/user/layout", () => {
-    afterEach(() => {
-        jest.clearAllMocks();
+mock.module("@/lib/auth", {
+    namedExports: { authOptions: {} },
+});
+
+const userUpdate = (args: unknown) => {
+    capturedUpdateArgs = args;
+    return Promise.resolve(updateResult);
+};
+
+mock.module("@/lib/prisma", {
+    defaultExport: { user: { update: userUpdate } },
+    namedExports: { prisma: { user: { update: userUpdate } } },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let PATCH: (...args: any[]) => Promise<Response>;
+
+before(async () => {
+    const route = await import("@/app/api/user/layout/route");
+    PATCH = route.PATCH;
+});
+
+function makeReq(body: unknown) {
+    return new NextRequest("http://localhost/api/user/layout", {
+        method: "PATCH",
+        body: JSON.stringify(body),
     });
+}
 
-    it("should return 401 if unauthorized", async () => {
-        (getServerSession as jest.Mock).mockResolvedValue(null);
+test("returns 401 when unauthorized", async () => {
+    mockSession = null;
+    const res = await PATCH(makeReq({ layoutStyle: "GRID" }));
+    assert.equal(res.status, 401);
+    assert.equal((await res.json()).error, "Unauthorized");
+});
 
-        const req = new NextRequest("http://localhost/api/user/layout", {
-            method: "PATCH",
-            body: JSON.stringify({ layoutStyle: "GRID" }),
-        });
+test("returns 400 for an invalid layoutStyle", async () => {
+    mockSession = { user: { email: "test@example.com" } };
+    const res = await PATCH(makeReq({ layoutStyle: "INVALID" }));
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error, "Invalid layout style");
+});
 
-        const res = await PATCH(req);
-        expect(res.status).toBe(401);
-        const data = await res.json();
-        expect(data.error).toBe("Unauthorized");
-    });
+test("returns 200 and updates the layoutStyle", async () => {
+    mockSession = { user: { email: "test@example.com" } };
+    capturedUpdateArgs = null;
+    updateResult = { layoutStyle: "GRID" };
 
-    it("should return 400 for invalid layoutStyle", async () => {
-        (getServerSession as jest.Mock).mockResolvedValue({
-            user: { email: "test@example.com" },
-        });
-
-        const req = new NextRequest("http://localhost/api/user/layout", {
-            method: "PATCH",
-            body: JSON.stringify({ layoutStyle: "INVALID" }),
-        });
-
-        const res = await PATCH(req);
-        expect(res.status).toBe(400);
-        const data = await res.json();
-        expect(data.error).toBe("Invalid layout style");
-    });
-
-    it("should return 200 and update layoutStyle", async () => {
-        (getServerSession as jest.Mock).mockResolvedValue({
-            user: { email: "test@example.com" },
-        });
-        (prisma.user.update as jest.Mock).mockResolvedValue({
-            layoutStyle: "GRID",
-        });
-
-        const req = new NextRequest("http://localhost/api/user/layout", {
-            method: "PATCH",
-            body: JSON.stringify({ layoutStyle: "GRID" }),
-        });
-
-        const res = await PATCH(req);
-        expect(res.status).toBe(200);
-        const data = await res.json();
-        expect(data.success).toBe(true);
-        expect(data.layoutStyle).toBe("GRID");
-
-        expect(prisma.user.update).toHaveBeenCalledWith({
-            where: { email: "test@example.com" },
-            data: { layoutStyle: "GRID" },
-        });
+    const res = await PATCH(makeReq({ layoutStyle: "GRID" }));
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.success, true);
+    assert.equal(data.layoutStyle, "GRID");
+    assert.deepEqual(capturedUpdateArgs, {
+        where: { email: "test@example.com" },
+        data: { layoutStyle: "GRID" },
     });
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "migrate:deploy:safe": "node scripts/safe-prisma-migrate-deploy.mjs",
     "dbpush": "prisma db push",
     "lint": "eslint",
+    "pretest": "node scripts/pretest-prisma-generate.mjs",
     "test": "tsx --test --experimental-test-module-mocks lib/**/*.test.ts app/**/*.test.ts",
     "test:ui": "jest",
     "test:ui:watch": "jest --watch"

--- a/scripts/pretest-prisma-generate.mjs
+++ b/scripts/pretest-prisma-generate.mjs
@@ -1,0 +1,13 @@
+import { execSync } from "node:child_process";
+
+// The test suite imports routes that pull in `@prisma/client`, so the client
+// must be generated first. `prisma generate` does not connect to the database,
+// but prisma.config.ts throws when no connection string is set (the fresh-clone
+// default), which would block generation. Supply a harmless placeholder for the
+// generate step only, so `npm test` works on a fresh clone with no DB env.
+const env = { ...process.env };
+if (!env.DATABASE_URL && !env.DIRECT_URL) {
+  env.DATABASE_URL = "postgresql://placeholder:placeholder@localhost:5432/placeholder";
+}
+
+execSync("npx prisma generate", { stdio: "inherit", env });


### PR DESCRIPTION
## 🐛 What this fixes

Closes #568

`npm test` failed on a fresh clone because the `test` script never generated the Prisma client, so route tests couldn't resolve `@prisma/client` (`Cannot find module '.prisma/client/default'`).

## 🔧 Changes

**1. Generate the Prisma client before tests.**
Added a `pretest` step. `prisma generate` doesn't connect to a database, but this repo's `prisma.config.ts` throws when no connection string is set (the fresh-clone default), which blocks generation. So `scripts/pretest-prisma-generate.mjs` supplies a harmless placeholder `DATABASE_URL` for the generate step *only* (no DB connection is made) and then runs `prisma generate`.

**2. Convert `app/api/user/layout/route.test.ts` to the node:test runner.**
It was the one file still using the **jest** API (`jest.mock`/`jest.fn`). Under the `tsx --test` runner those mocks were no-ops, so the real `@/lib/auth` loaded and threw `server-only` ("cannot be imported from a Client Component"). Rewrote it in the `node:test` + `mock.module` pattern the rest of the suite already uses, so `@/lib/auth`, `next-auth`, and `@/lib/prisma` are mocked cleanly.

## ✅ Result

`npm test` now passes **132/132** on a fresh clone with no database configured.

```
# tests 132
# pass 132
# fail 0
```

> Wiring `npm test` into CI is tracked separately in #564 (the CI no-op finding).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated route test coverage while preserving checks for unauthorized requests, invalid styles, and successful updates.
  * Added verification that successful updates use the expected database parameters.

* **Chores**
  * Tests now automatically generate the Prisma client before running, including in environments without a configured database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->