### PR TITLE
fix: resolve partial transaction commit bug in link reordering (#575)

### DIFF
--- a/app/api/links/reorder/route.ts
+++ b/app/api/links/reorder/route.ts
@@ -130,18 +130,25 @@ export async function POST(req: Request) {
     if (updates.length === 0) return NextResponse.json({ ok: true, changed: 0 });
 
     // Atomic update with ownership check to avoid TOCTOU races
-    const results = await prisma.$transaction(
-      updates.map((u) =>
-        prisma.link.updateMany({
-          where: { id: u.id, userId: user.id },
-          data: { position: u.newOrder, parentId: u.newParentId },
-        })
-      )
-    );
+    try {
+      await prisma.$transaction(async (tx) => {
+        for (const u of updates) {
+          const result = await tx.link.updateMany({
+            where: { id: u.id, userId: user.id },
+            data: { position: u.newOrder, parentId: u.newParentId },
+          });
 
-    // Ensure each update affected exactly one row (ownership preserved)
-    if (results.some((r) => r.count !== 1)) {
-      return NextResponse.json({ error: "Reorder conflict, please retry" }, { status: 409 });
+          // Ensure each update affected exactly one row (ownership preserved)
+          if (result.count !== 1) {
+            throw new Error("REORDER_CONFLICT");
+          }
+        }
+      });
+    } catch (err) {
+      if (err instanceof Error && err.message === "REORDER_CONFLICT") {
+        return NextResponse.json({ error: "Reorder conflict, please retry" }, { status: 409 });
+      }
+      throw err;
     }
 
     return NextResponse.json({ ok: true, changed: updates.length });


### PR DESCRIPTION
## 🐛 Bug Fixes
This PR resolves the issue described in #575 where TOCTOU (Time-Of-Check to Time-Of-Use) races resulted in partial database commits during link reordering. 

Previously, the endpoint used an array-based `$transaction` with `updateMany`. Since `updateMany` returns `{ count: 0 }` instead of throwing an error when no records are matched, a concurrent deletion or missing link would allow the transaction to commit successfully, corrupting the database by reordering only some of the links.

## 🛠️ Changes made
- Migrated the `app/api/links/reorder/route.ts` endpoint to use an Interactive Transaction (`prisma.$transaction(async (tx) => { ... })`).
- Actively evaluated the returned `count` from each `updateMany` query sequentially inside the transaction body.
- Thrown an explicit `Error("REORDER_CONFLICT")` if an update does not match exactly one row (`count !== 1`), triggering Prisma's automatic rollback.
- Caught the error gracefully to maintain the existing `409 Conflict: Reorder conflict, please retry` response, ensuring the database remains completely intact.

## 🧪 Testing
- Intercepting network requests and attempting to reorder links while concurrently deleting one now successfully triggers a rollback.
- Confirmed that returning the 409 status code leaves the database exactly as it was before the request.

Closes #575


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link reordering reliability by applying updates atomically.
  * Added conflict handling that returns a clear conflict response when reordering cannot be completed.
  * Preserved existing error handling for unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->