### PR TITLE
fix(redirect): enforce schedule window on the direct link route (#566)

### DIFF
--- a/app/[username]/[platform]/page.tsx
+++ b/app/[username]/[platform]/page.tsx
@@ -44,6 +44,11 @@ export default async function PlatformRedirect({
     const resolved = await resolveUserByUsername(username);
     if (!resolved) notFound();
 
+    // Enforce the schedule window here too — the profile list hides links
+    // outside their window, but the direct redirect route must not resolve,
+    // track, or 302 to a not-yet-active or already-expired link.
+    const now = new Date();
+
     const link = await prisma.link.findFirst({
         where: {
             userId: resolved.user.id,
@@ -51,7 +56,11 @@ export default async function PlatformRedirect({
             OR: [
                 { alias: normalizedPlatform },
                 { platform: normalizedPlatform, alias: null }
-            ]
+            ],
+            AND: [
+                { OR: [{ startDate: null }, { startDate: { lte: now } }] },
+                { OR: [{ endDate: null }, { endDate: { gte: now } }] },
+            ],
         },
         select: { id: true, url: true, userId: true, platform: true },
     });


### PR DESCRIPTION
## 🐛 What this fixes

Closes #566

Scheduled / expired links are correctly hidden from the profile list (`app/[username]/page.tsx` filters on the `startDate`/`endDate` window), but the **direct redirect route** (`app/[username]/[platform]/page.tsx`) queried only `isPublic` + alias/platform — with no schedule predicate. So a not-yet-active or already-expired link was still reachable by slug, still recorded a click, and still 302'd to the target.

## 🔧 Change

Apply the same window to the `prisma.link.findFirst` `where` in the redirect route:

```ts
AND: [
  { OR: [{ startDate: null }, { startDate: { lte: now } }] },
  { OR: [{ endDate: null }, { endDate: { gte: now } }] },
]
```

Null bounds mean "unbounded" (matching the profile-list semantics). An out-of-window link no longer resolves — the route returns `notFound()` and records no click.

## ✅ Testing

- `tsc --noEmit` — the redirect page typechecks cleanly (the filters are valid on the nullable `DateTime` columns).
- Reasoned through: future `startDate` or past `endDate` → no row matches → `notFound()`, no `trackLinkClick`.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
