### PR TITLE
fix(profile): select only public fields for public reads — keep password/email out of cache (#567)

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 import { ProfileCard } from "./ProfileCard";
 import { ProfileFooter } from "./ProfileFooter";
@@ -83,8 +84,17 @@ export default async function PublicProfile({
   const { getPublicUserData } = await import("@/lib/userLookup");
   const publicUserData = await getPublicUserData(resolved.canonicalUsername);
 
-  const isOwner =
-    session?.user?.email?.toLowerCase() === user.email?.toLowerCase();
+  // Compare against the owner's email fetched separately (server-side, uncached)
+  // so credential/PII fields never enter the public profile cache.
+  let isOwner = false;
+  if (session?.user?.email) {
+    const owner = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { email: true },
+    });
+    isOwner =
+      owner?.email?.toLowerCase() === session.user.email.toLowerCase();
+  }
 
   const bgStyle: React.CSSProperties = {};
   if (user.themeType === "solid") {

--- a/app/api/export/vcard/[username]/route.ts
+++ b/app/api/export/vcard/[username]/route.ts
@@ -9,7 +9,13 @@ export async function GET(
     const { username } = await params;
     const user = await prisma.user.findUnique({
       where: { username },
-      include: {
+      // Only the fields the vCard needs — never the password hash or TOTP columns.
+      select: {
+        name: true,
+        username: true,
+        bio: true,
+        image: true,
+        email: true,
         links: {
           where: { isPublic: true },
         },

--- a/lib/buildVCard.ts
+++ b/lib/buildVCard.ts
@@ -4,7 +4,7 @@ export function buildVCard({
   user,
   links,
 }: {
-  user: PrismaUser;
+  user: Pick<PrismaUser, "name" | "username" | "email" | "bio" | "image">;
   links: PrismaLink[];
 }): string {
   const CRLF = "\r\n";

--- a/lib/userLookup.ts
+++ b/lib/userLookup.ts
@@ -1,15 +1,37 @@
 import prisma from "@/lib/prisma";
 import { unstable_cache } from "next/cache";
-import type { Link } from "@prisma/client";
+import { Prisma, type Link } from "@prisma/client";
 
 import { nestLinks } from "./linkTree";
 
+// Only public profile fields — never `password`, `email`, `emailVerified`, or
+// TOTP columns. This object is cached by unstable_cache and rendered into the
+// public, unauthenticated profile tree, so credential material must not be here.
+const publicProfileSelect = {
+    id: true,
+    name: true,
+    username: true,
+    bio: true,
+    image: true,
+    theme: true,
+    themeType: true,
+    themeColor: true,
+    themeCustom: true,
+    layoutStyle: true,
+    enableEmailCapture: true,
+    seoTitle: true,
+    seoDescription: true,
+    links: {
+        where: { isPublic: true },
+        orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+    },
+} satisfies Prisma.UserSelect;
 
 export const resolveUserByUsername = unstable_cache(
     async (username: string) => {
         const exactUser = await prisma.user.findUnique({
             where: { username },
-            include: { links: { where: { isPublic: true }, orderBy: [{ position: "asc" }, { createdAt: "asc" }] } },
+            select: publicProfileSelect,
         });
 
         if (exactUser) {
@@ -26,7 +48,7 @@ export const resolveUserByUsername = unstable_cache(
 
         const user = await prisma.user.findUnique({
             where: { id: alias.userId },
-            include: { links: { where: { isPublic: true }, orderBy: [{ position: "asc" }, { createdAt: "asc" }] } },
+            select: publicProfileSelect,
         });
 
         if (!user) {


### PR DESCRIPTION
## 🐛 What this fixes

Closes #567

`resolveUserByUsername` (the public-profile lookup) used `include` with no `select`, so the **entire `User` row** — bcrypt `password` hash, `email`, `emailVerified`, TOTP fields — was:
- fetched and written into `unstable_cache`'s persistent Data Cache for 60s of anonymous reads, and
- held in the RSC render tree of the public, unauthenticated profile page.

The public vCard route (`app/api/export/vcard/[username]/route.ts`) had the same `include`-without-`select`.

## 🔧 Changes

- **`lib/userLookup.ts`** — `resolveUserByUsername` now selects only public profile fields (`id, name, username, bio, image, theme, themeType, themeColor, themeCustom, layoutStyle, enableEmailCapture, seoTitle, seoDescription` + `links`). Defined once as `publicProfileSelect satisfies Prisma.UserSelect`. No `password`/`email`/TOTP columns enter the cache.
- **`app/[username]/page.tsx`** — `isOwner` was the only consumer of the cached `email`. It now fetches the owner's email in a separate, **uncached** query (only when a session exists), so email never lands in the Data Cache.
- **`app/api/export/vcard/[username]/route.ts`** — selects only the fields the card needs (`name, username, bio, image, email, links`); no password/TOTP. (Email is legitimate on a vCard.)
- **`lib/buildVCard.ts`** — param type narrowed to the fields it actually reads.

## ✅ Testing

- `tsc --noEmit` — no new errors from these changes (all consumers — profile page, redirect page, opengraph-image, vCard — were verified to only use selected fields).
- The 3 pre-existing `tsc` errors in unrelated test files are untouched.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile ownership checks by validating against the signed-in account’s email.
  * Restricted profile and vCard data retrieval to the information required for display and export.
  * Continued supporting username aliases while returning only public profile details and ordered links.
* **Security**
  * Reduced exposure of private account and credential-related information during profile lookups and vCard exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->