### PR TITLE
fix(domain): resolve custom domains instead of 404ing (#565)

### DIFF
--- a/app/domain/[host]/[[...path]]/page.tsx
+++ b/app/domain/[host]/[[...path]]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import prisma from "@/lib/prisma";
+import PublicProfile from "@/app/[username]/page";
+
+// Custom-domain handler. middleware.ts rewrites requests on a pointed custom
+// domain to /domain/{host}{path}; resolve the owner by customDomain and render
+// the same public profile the /{username} route renders.
+export default async function DomainProfile({
+    params,
+}: {
+    params: Promise<{ host: string; path?: string[] }>;
+}) {
+    const { host } = await params;
+
+    const owner = await prisma.user.findUnique({
+        where: { customDomain: host },
+        select: { username: true },
+    });
+
+    if (!owner?.username) {
+        notFound();
+    }
+
+    return <PublicProfile params={Promise.resolve({ username: owner.username })} />;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,8 +20,15 @@ export async function middleware(req: NextRequest) {
 
     const host = req.headers.get("host");
     const isLocal = host?.includes("localhost") || host?.includes("127.0.0.1");
-    const isBaseDomain = host?.includes("linkid.qzz.io") || host?.includes(process.env.NEXT_PUBLIC_APP_URL?.replace("https://", "") || "");
-    const isCustomDomain = host && !isLocal && !isBaseDomain;
+    // Exact host match — the previous `includes(...)` collapsed to `includes("")`
+    // (always true) when NEXT_PUBLIC_APP_URL was unset, so custom domains were
+    // never detected.
+    const appHost = process.env.NEXT_PUBLIC_APP_URL
+        ?.replace(/^https?:\/\//, "")
+        .replace(/\/.*$/, "");
+    const baseHosts = ["linkid.qzz.io", appHost].filter(Boolean) as string[];
+    const isBaseDomain = !!host && baseHosts.some((h) => host === h || host.endsWith(`.${h}`));
+    const isCustomDomain = !!host && !isLocal && !isBaseDomain;
 
     if (isCustomDomain) {
         // Rewrite to a special domain handler route that will fetch the user by domain


### PR DESCRIPTION
## 🐛 What this fixes

Closes #565

Custom-domain handling was half-wired, so every custom domain 404'd:

1. **No `app/domain/` route.** `middleware.ts` rewrites custom-domain requests to `/domain/{host}{path}`, but that route didn't exist — the rewrite target 404'd.
2. **Broken base-domain check.** `host.includes(NEXT_PUBLIC_APP_URL?.replace("https://","") || "")` collapses to `host.includes("")` (always `true`) when `NEXT_PUBLIC_APP_URL` is unset, so `isBaseDomain` was always true and custom domains were never detected in dev.

## 🔧 Changes

- **`middleware.ts`** — detect the base domain by **exact host match** (plus subdomain suffix) against the known base hosts (`linkid.qzz.io` and, when set, the `NEXT_PUBLIC_APP_URL` host), instead of the `includes("")` trap. The DB lookup stays out of middleware (edge-safe).
- **`app/domain/[host]/[[...path]]/page.tsx`** (new) — resolves the owner by `customDomain` (a `@unique` column) and renders the **same** public profile the `/{username}` route renders, by delegating to that page component (no duplication). Unknown host → `notFound()`.

## ✅ Testing

- `tsc --noEmit` — no new type errors.
- `eslint` — clean on both changed files.
- The custom-domain runtime flow (DNS → middleware rewrite → domain route) can't be exercised from a local clone without a pointed domain + database, so it was verified by type-check, lint, and tracing the rewrite path; the render path reuses the already-working `/{username}` profile page.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
