### PR TITLE
feat: implement verified badge system

### DIFF
--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -22,6 +22,7 @@ export function ProfileCard(props: ProfileCardProps) {
                     username={username}
                     bio={user.bio}
                     image={user.image}
+                    isVerified={user.isVerified}
                 />
             </CardHeader>
 

--- a/app/[username]/ProfileHeader.tsx
+++ b/app/[username]/ProfileHeader.tsx
@@ -1,8 +1,9 @@
 import type { ProfileHeader } from "./types/type";
 import Image from "next/image";
+import { BadgeCheck } from "lucide-react";
 
 export function ProfileHeader(props: ProfileHeader) {
-    const { name, username, bio, image } = props;
+    const { name, username, bio, image, isVerified } = props;
     return (
         <div className="text-center space-y-2">
             <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-muted text-2xl font-bold overflow-hidden">
@@ -19,7 +20,10 @@ export function ProfileHeader(props: ProfileHeader) {
                 )}
             </div>
             <div>
-                <h1 className="text-2xl font-bold">{name ?? username}</h1>
+                <h1 className="text-2xl font-bold flex items-center justify-center gap-1">
+                    {name ?? username}
+                    {isVerified && <BadgeCheck className="w-5 h-5 text-blue-500 fill-blue-500/20" />}
+                </h1>
                 <p className="text-sm text-muted-foreground">@{username}</p>
                 {bio && (
                     <p className="text-sm text-balance mt-3">

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -153,6 +153,7 @@ export default async function PublicProfile({
             resumeUrl: publicUserData?.resumeUrl ?? null,
             enableEmailCapture: user.enableEmailCapture,
             layoutStyle: user.layoutStyle,
+            isVerified: user.isVerified,
           }}
           username={resolved.canonicalUsername}
           showCTA={!session}

--- a/app/[username]/types/type.d.ts
+++ b/app/[username]/types/type.d.ts
@@ -35,6 +35,7 @@ export type User = {
         resumeUrl?: string | null;
         enableEmailCapture?: boolean;
         layoutStyle?: LayoutStyle | string;
+        isVerified?: boolean;
     };
     username: string;
     showCTA: boolean;
@@ -57,6 +58,7 @@ export type ProfileHeader = {
     username: string;
     bio?: string | null;
     image?: string | null;
+    isVerified?: boolean;
 }
 
 export type ProfileLinks = {

--- a/app/api/admin/verify-user/route.ts
+++ b/app/api/admin/verify-user/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+export async function POST(req: Request) {
+    try {
+        const session = await getServerSession(authOptions);
+
+        if (!session?.user?.email) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const currentUser = await prisma.user.findUnique({
+            where: { email: session.user.email },
+        });
+
+        if (!currentUser || currentUser.role !== "ADMIN") {
+            return NextResponse.json({ error: "Forbidden: Admin access required" }, { status: 403 });
+        }
+
+        const body = await req.json();
+        const { targetUserId, isVerified } = body;
+
+        if (!targetUserId || typeof isVerified !== 'boolean') {
+            return NextResponse.json({ error: "Invalid parameters" }, { status: 400 });
+        }
+
+        const updatedUser = await prisma.user.update({
+            where: { id: targetUserId },
+            data: { isVerified },
+        });
+
+        return NextResponse.json({ success: true, user: updatedUser });
+    } catch (error) {
+        console.error("Error verifying user:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/lib/userLookup.ts
+++ b/lib/userLookup.ts
@@ -22,6 +22,7 @@ const publicProfileSelect = {
     enableEmailCapture: true,
     seoTitle: true,
     seoDescription: true,
+    isVerified: true,
     links: {
         where: { isPublic: true },
         orderBy: [{ position: "asc" }, { createdAt: "asc" }],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,11 @@ enum LayoutStyle {
   GRID
 }
 
+enum Role {
+  USER
+  ADMIN
+}
+
 model User {
   id            String   @id @default(uuid())
   name          String?
@@ -46,6 +51,8 @@ model User {
   profileVersions ProfileVersion[]
   previewTokens ProfilePreviewToken[]
   subscribers   Subscriber[]
+  isVerified    Boolean  @default(false)
+  role          Role     @default(USER)
   createdAt     DateTime @default(now())
 
   theme         String   @default("default")


### PR DESCRIPTION
**Description:**
This PR introduces the "Verified Badge" feature for platform administrators to verify notable accounts, as detailed in #653. Verified accounts will now display a blue checkmark next to their username on their public profile, adding a layer of trust and prestige to the platform. 

### Changes Made
- **Database Schema**: 
  - Added an `isVerified` boolean column (default `false`) to the `User` model.
  - Added a `Role` enum with options `USER` and `ADMIN` (default `USER`) to the `User` model.
- **Public Profile UI**:
  - Updated `ProfileCard` and `ProfileHeader` components to display an inline blue SVG checkmark (`BadgeCheck` from `lucide-react`) next to the username if `isVerified` is true.
  - Ensured that `isVerified` state is properly fetched and passed down through the public user resolution logic (`lib/userLookup.ts`).
- **Admin API**: 
  - Created a protected API route `/api/admin/verify-user` which allows users with the `ADMIN` role to securely toggle the verification status of any target account. 

### Resolves
Closes #653