### PR TITLE
fix: CSRF protection is inert on all /api/* routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,8 +5,18 @@ import type { NextRequest } from "next/server";
 import { applyCsrfProtection } from "@/lib/middleware/csrf";
 
 export async function middleware(req: NextRequest) {
-    const token = await getToken({ req });
     const { pathname } = req.nextUrl;
+
+    // API routes: apply CSRF protection only. The rest of this middleware
+    // (auth redirects, custom-domain rewrite, CSP nonce) is for page
+    // navigations, not API calls. The matcher previously excluded /api
+    // entirely, so applyCsrfProtection never ran on the mutating API routes.
+    if (pathname.startsWith("/api")) {
+        const csrfResponse = await applyCsrfProtection(req);
+        return csrfResponse ?? NextResponse.next();
+    }
+
+    const token = await getToken({ req });
 
     // If logged in & trying to access /login or /register → redirect to dashboard
     if (token && (pathname === "/login" || pathname === "/register")) {
@@ -76,11 +86,13 @@ export const config = {
     matcher: [
         /*
          * Match all request paths except for the ones starting with:
-         * - api (API routes)
          * - _next/static (static files)
          * - _next/image (image optimization files)
          * - favicon.ico (favicon file)
+         *
+         * /api is intentionally included so CSRF protection runs on API
+         * routes; the handler short-circuits API requests to CSRF only.
          */
-        "/((?!api|_next/static|_next/image|favicon.ico).*)",
+        "/((?!_next/static|_next/image|favicon.ico).*)",
     ],
 };


### PR DESCRIPTION
Closes #646

### Problem
`applyCsrfProtection` is imported and invoked in `middleware.ts`, but the middleware `config.matcher` excluded `api` (`"/((?!api|_next/...).*)"`). So the middleware — and therefore the CSRF check — never ran for any `/api/*` route, leaving every mutating API endpoint unprotected.

### Fix
- Include `/api` in the matcher.
- Short-circuit API requests at the top of the middleware to run **only** `applyCsrfProtection`, so the page-navigation logic (auth redirects, custom-domain rewrite, CSP nonce) is not applied to API calls — preserving current behaviour for API routes apart from adding CSRF.

The existing CSRF decision logic already scopes protection to POST/PUT/PATCH/DELETE and excludes safe paths (`/api/auth`, `/api/csrf`, `/api/contact-us`, `/api/links/click`, `/api/analytics/aggregate`), so no legitimate request is affected.

### Testing
- `npx tsc --noEmit` clean on `middleware.ts`.
- Existing CSRF unit tests (`lib/csrf.test.ts`, `lib/middleware/csrf.test.ts`) pass (8/8).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API requests now receive CSRF protection before other request processing.
  * API routes avoid page-specific authentication, domain rewriting, and content security handling, improving compatibility and reliability.
  * Updated request matching ensures API endpoints are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->