### PR TITLE
fix: account merge skips confirmation for OAuth-only users

### DIFF
--- a/app/api/profile/merge/complete/route.ts
+++ b/app/api/profile/merge/complete/route.ts
@@ -14,6 +14,7 @@ export async function POST(req: Request) {
     const body = await req.json().catch(() => ({} as Record<string, unknown>));
     const code = typeof body.code === "string" ? body.code : "";
     const password = typeof body.password === "string" ? body.password : undefined;
+    const confirmEmail = typeof body.confirmEmail === "string" ? body.confirmEmail : undefined;
 
     if (!code) {
         return NextResponse.json({ error: "Merge code is required" }, { status: 400 });
@@ -33,6 +34,7 @@ export async function POST(req: Request) {
             sourceUserId: sourceUser.id,
             code,
             password,
+            confirmEmail,
         });
 
         return NextResponse.json({

--- a/app/api/profile/merge/request/route.ts
+++ b/app/api/profile/merge/request/route.ts
@@ -13,6 +13,7 @@ export async function POST(req: Request) {
 
     const body = await req.json().catch(() => ({} as Record<string, unknown>));
     const password = typeof body.password === "string" ? body.password : undefined;
+    const confirmEmail = typeof body.confirmEmail === "string" ? body.confirmEmail : undefined;
 
     try {
         const targetUser = await prisma.user.findUnique({
@@ -27,6 +28,7 @@ export async function POST(req: Request) {
         const result = await createMergeRequest({
             targetUserId: targetUser.id,
             password,
+            confirmEmail,
         });
 
         return NextResponse.json({

--- a/lib/accountMerge.ts
+++ b/lib/accountMerge.ts
@@ -14,26 +14,58 @@ export class MergeError extends Error {
     }
 }
 
-async function verifyPasswordIfPresent(userId: string, password: string | undefined) {
+async function verifyMergeConfirmation(
+    userId: string,
+    confirmation: { password?: string; confirmEmail?: string }
+) {
     const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { password: true },
+        select: { password: true, email: true },
     });
 
+    // Password accounts confirm the destructive merge with their password.
     if (user?.password) {
-        if (!password) {
+        if (!confirmation.password) {
             throw new MergeError("Password confirmation is required", 400);
         }
 
-        const isValid = await bcrypt.compare(password, user.password);
+        const isValid = await bcrypt.compare(confirmation.password, user.password);
         if (!isValid) {
             throw new MergeError("Password confirmation failed", 401);
         }
+        return;
     }
+
+    // OAuth-only accounts have no password. Previously the check was skipped
+    // entirely, so a merge (irreversible) could be triggered with no
+    // confirmation at all. Require the owner to re-type their account email so
+    // the action can't proceed silently on a bare authenticated/replayed request.
+    if (user?.email) {
+        const provided = confirmation.confirmEmail?.trim().toLowerCase();
+        if (!provided) {
+            throw new MergeError(
+                "Please re-enter your account email to confirm this merge",
+                400
+            );
+        }
+        if (provided !== user.email.toLowerCase()) {
+            throw new MergeError("Email confirmation did not match", 401);
+        }
+        return;
+    }
+
+    throw new MergeError("This account cannot be verified for merge", 400);
 }
 
-export async function createMergeRequest(input: { targetUserId: string; password?: string }) {
-    await verifyPasswordIfPresent(input.targetUserId, input.password);
+export async function createMergeRequest(input: {
+    targetUserId: string;
+    password?: string;
+    confirmEmail?: string;
+}) {
+    await verifyMergeConfirmation(input.targetUserId, {
+        password: input.password,
+        confirmEmail: input.confirmEmail,
+    });
 
     const code = generateMergeCode();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
@@ -64,6 +96,7 @@ export async function completeAccountMerge(input: {
     sourceUserId: string;
     code: string;
     password?: string;
+    confirmEmail?: string;
 }) {
     const requestCodeHash = hashMergeCode(input.code);
     const mergeRequest = await prisma.accountMergeRequest.findUnique({
@@ -86,7 +119,10 @@ export async function completeAccountMerge(input: {
         throw new MergeError("You cannot merge an account into itself", 400);
     }
 
-    await verifyPasswordIfPresent(input.sourceUserId, input.password);
+    await verifyMergeConfirmation(input.sourceUserId, {
+        password: input.password,
+        confirmEmail: input.confirmEmail,
+    });
 
     const [sourceUser, targetUser] = await Promise.all([
         prisma.user.findUnique({


### PR DESCRIPTION
Closes #647

### Problem
`verifyPasswordIfPresent` only enforced a confirmation when `user.password` existed:
```ts
if (user?.password) { /* require + bcrypt.compare password */ }
// OAuth-only users (no password) fell straight through — no confirmation
```
So an OAuth-only account could complete a merge — a destructive, irreversible action — with no confirmation step at all (and, before the CSRF fix, not even CSRF-protected).

### Fix
Replaced it with `verifyMergeConfirmation`, applied on both merge **request** and **complete**:
- **Password accounts** — unchanged: confirm with the account password.
- **OAuth-only accounts** — must re-type their account email (`confirmEmail`), which the server verifies against the account. This is the standard "type your identifier to confirm" gate for passwordless accounts and prevents the merge from proceeding silently on a bare authenticated/replayed request.

`confirmEmail` is threaded through both API routes. **Client note:** the merge dialog should collect `confirmEmail` for accounts without a password (happy to do the UI follow-up if you point me at the component).

### Testing
- `npx tsc --noEmit` clean on the changed files.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._