### PR TITLE
fix: first-time username publish skips the in-transaction uniqueness check

### DIFF
--- a/lib/profileWorkflow.ts
+++ b/lib/profileWorkflow.ts
@@ -274,8 +274,11 @@ export async function publishProfileDraft(
     // Calculate diff
     const diff = diffProfileSnapshots(beforeSnapshot, afterSnapshot);
 
-    // Handle username change - create alias for old username
-    if (beforeSnapshot.username && beforeSnapshot.username !== afterSnapshot.username) {
+    // Handle username being set or changed. Run the in-transaction uniqueness
+    // recheck whenever the username differs from before — including the first
+    // publish (beforeSnapshot.username empty), which previously skipped the
+    // check entirely and let two accounts claim the same handle concurrently.
+    if (afterSnapshot.username && afterSnapshot.username !== beforeSnapshot.username) {
       // Recheck availability within the transaction to guard against TOCTOU races
       const takenByOther = await tx.user.findFirst({
         where: { username: afterSnapshot.username, NOT: { id: userId } },
@@ -283,7 +286,10 @@ export async function publishProfileDraft(
       if (takenByOther) {
         throw new Error("Username already taken");
       }
-      await ensureUsernameAliases(tx, userId, beforeSnapshot.username);
+      // Only alias the previous username on a rename, not on first publish.
+      if (beforeSnapshot.username) {
+        await ensureUsernameAliases(tx, userId, beforeSnapshot.username);
+      }
     }
 
     // Update the live profile


### PR DESCRIPTION
Closes #648

### Problem
The publish transaction only rechecked username availability when the username was **changing** from an existing value:
```ts
if (beforeSnapshot.username && beforeSnapshot.username !== afterSnapshot.username) { ... }
```
On a **first** publish `beforeSnapshot.username` is empty, so the whole block — including the TOCTOU-guarding uniqueness recheck the code was explicitly written to do for renames — was skipped. Two accounts publishing the same handle for the first time concurrently could both pass any earlier check and collide.

### Fix
Run the recheck whenever `afterSnapshot.username` is being set and differs from before (covers first publish and rename), and only create the alias for the previous username on a rename (when `beforeSnapshot.username` exists).

### Testing
- `npx tsc --noEmit` clean on the changed file.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._