### PR TITLE
fix: /api/links/click records clicks on private links

### DIFF
--- a/app/api/links/click/route.ts
+++ b/app/api/links/click/route.ts
@@ -27,8 +27,11 @@ export async function POST(req: Request) {
         return NextResponse.json({ error: "Missing params" }, { status: 400 });
     }
 
+    // Only public links are click-trackable. Without this filter, clicks were
+    // recorded against links the owner has marked private (isPublic: false),
+    // which aren't shown publicly in the first place.
     const link = await prisma.link.findFirst({
-        where: { platform, user: { username } },
+        where: { platform, user: { username }, isPublic: true },
         select: { id: true, userId: true },
     });
 


### PR DESCRIPTION
Closes #649

### Problem
`POST /api/links/click` looked up the link with `where: { platform, user: { username } }` and no visibility filter. `Link.isPublic` exists in the schema (default `true`), but it wasn’t checked — so clicks were recorded against links the owner marked **private** (`isPublic: false`), which aren’t shown publicly.

### Fix
Add `isPublic: true` to the lookup, so private links return `404` and aren’t click-tracked.

Note: the endpoint already has per-IP rate limiting (30/min), which mitigates the click-inflation angle; this PR closes the private-link tracking gap.

### Testing
- `npx tsc --noEmit` clean on the changed route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._