### PR TITLE
feat: add search & filter bar on public profile (#666)

### DIFF
--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ProfileHeader } from "./ProfileHeader";
 import { ProfileLinks } from "./ProfileLinks";
@@ -5,10 +8,11 @@ import { ProfileCTA } from "./ProfileCTA";
 import { ProfileCardProps } from "./types/type";
 import { NewsletterSubscribeBlock } from "./NewsletterSubscribeBlock";
 import { PLATFORM_ICONS } from "@/lib/platformIcons";
-import { Globe } from "lucide-react";
+import { Globe, Search } from "lucide-react";
 
 export function ProfileCard(props: ProfileCardProps) {
     const { user, username, showCTA, isOwner, themeType } = props;
+    const [searchQuery, setSearchQuery] = useState("");
 
     const cardClassName = 
       themeType === "glassmorphism" ? "bg-white/5 border border-white/10 backdrop-blur-md text-white shadow-2xl" :
@@ -16,16 +20,52 @@ export function ProfileCard(props: ProfileCardProps) {
       themeType === "cyberpunk" ? "bg-zinc-950 border border-pink-500 text-cyan-400 shadow-[0_0_20px_rgba(244,63,94,0.4)] hover:-translate-y-2 transition-all duration-300" :
       "transition-all duration-300 hover:-translate-y-2 hover:shadow-xl";
 
+    const query = searchQuery.trim().toLowerCase();
+
     const socialLinks = (user.links ?? []).flatMap((link) =>
         link.isGroup ? (link.children ?? []).filter((c) => c.isSocialIcon) : (link.isSocialIcon ? [link] : [])
-    );
+    ).filter(link => {
+        if (!query) return true;
+        const label = (link.label || "").toLowerCase();
+        const platform = (link.platform || "").toLowerCase();
+        return label.includes(query) || platform.includes(query);
+    });
+
     const regularLinks = (user.links ?? []).flatMap((link) => {
         if (link.isGroup) {
             const regularChildren = (link.children ?? []).filter((c) => !c.isSocialIcon);
-            return regularChildren.length > 0 ? [{ ...link, children: regularChildren }] : [];
+            if (regularChildren.length === 0) return [];
+            
+            if (!query) return [{ ...link, children: regularChildren }];
+
+            const groupLabelMatch = (link.label || "").toLowerCase().includes(query);
+            if (groupLabelMatch) return [{ ...link, children: regularChildren }];
+
+            const matchingChildren = regularChildren.filter(c => {
+                const cLabel = (c.label || "").toLowerCase();
+                const cPlatform = (c.platform || "").toLowerCase();
+                return cLabel.includes(query) || cPlatform.includes(query);
+            });
+
+            if (matchingChildren.length > 0) {
+                return [{ ...link, children: matchingChildren }];
+            }
+            return [];
         }
-        return !link.isSocialIcon ? [link] : [];
+        
+        if (link.isSocialIcon) return [];
+
+        if (!query) return [link];
+        
+        const label = (link.label || "").toLowerCase();
+        const platform = (link.platform || "").toLowerCase();
+        if (label.includes(query) || platform.includes(query)) {
+            return [link];
+        }
+        return [];
     });
+
+    const noLinksFound = query.length > 0 && socialLinks.length === 0 && regularLinks.length === 0;
 
     return (
         <Card className={cardClassName}>
@@ -40,37 +80,58 @@ export function ProfileCard(props: ProfileCardProps) {
             </CardHeader>
 
             <CardContent className="space-y-3">
-                {socialLinks.length > 0 && (
-                    <div className="flex flex-wrap justify-center gap-4 pt-1 pb-3">
-                        {socialLinks.map((link) => {
-                            const Icon = PLATFORM_ICONS[link.platform] ?? Globe;
-                            return (
-                                <a
-                                    key={link.id}
-                                    href={`/${username}/${link.alias || link.platform}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-muted-foreground hover:text-foreground transition-colors hover:scale-110"
-                                    aria-label={link.label || link.platform}
-                                >
-                                    <Icon className="h-6 w-6" />
-                                </a>
-                            );
-                        })}
+                <div className="relative mb-2">
+                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <Search className="h-4 w-4 text-muted-foreground" />
                     </div>
-                )}
-
-                {user.enableEmailCapture && (
-                    <NewsletterSubscribeBlock username={username} />
-                )}
-
-                {(regularLinks.length > 0 || socialLinks.length === 0) && (
-                    <ProfileLinks
-                        links={regularLinks}
-                        username={username}
-                        isOwner={isOwner}
-                        layoutStyle={user.layoutStyle}
+                    <input
+                        type="search"
+                        placeholder="Search links..."
+                        className="w-full bg-background/50 border border-border rounded-lg pl-10 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
                     />
+                </div>
+
+                {noLinksFound ? (
+                    <div className="text-center py-6 text-sm text-muted-foreground">
+                        No links found
+                    </div>
+                ) : (
+                    <>
+                        {socialLinks.length > 0 && (
+                            <div className="flex flex-wrap justify-center gap-4 pt-1 pb-3">
+                                {socialLinks.map((link) => {
+                                    const Icon = PLATFORM_ICONS[link.platform] ?? Globe;
+                                    return (
+                                        <a
+                                            key={link.id}
+                                            href={`/${username}/${link.alias || link.platform}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-muted-foreground hover:text-foreground transition-colors hover:scale-110"
+                                            aria-label={link.label || link.platform}
+                                        >
+                                            <Icon className="h-6 w-6" />
+                                        </a>
+                                    );
+                                })}
+                            </div>
+                        )}
+
+                        {user.enableEmailCapture && (
+                            <NewsletterSubscribeBlock username={username} />
+                        )}
+
+                        {(regularLinks.length > 0 || socialLinks.length === 0) && (
+                            <ProfileLinks
+                                links={regularLinks}
+                                username={username}
+                                isOwner={isOwner}
+                                layoutStyle={user.layoutStyle}
+                            />
+                        )}
+                    </>
                 )}
 
                 {showCTA && <ProfileCTA />}

--- a/app/[username]/ProfileCard.tsx
+++ b/app/[username]/ProfileCard.tsx
@@ -87,6 +87,7 @@ export function ProfileCard(props: ProfileCardProps) {
                     <input
                         type="search"
                         placeholder="Search links..."
+                        aria-label="Search links"
                         className="w-full bg-background/50 border border-border rounded-lg pl-10 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}


### PR DESCRIPTION
**Fixes:** #666 

### ✨ Description
This PR introduces a client-side Search & Filter Bar at the top of the public profile, allowing visitors to instantly filter a user's visible links by typing keywords. 

As requested in the issue, this solves the problem of visitors having to scroll through dozens of links on prolific creators' profiles to find a specific platform or link.

### 🛠️ Changes Made
- Converted `app/[username]/ProfileCard.tsx` to a client component (`"use client"`) to manage React state.
- Added a `useState` hook for `searchQuery`.
- Rendered a sleek `<input type="search">` directly below the bio section, styled to match the existing UI with a magnifying glass icon.
- Implemented case-insensitive filtering for both `socialLinks` and `regularLinks` (including matching against links inside grouped folders). The filtering checks against both the link's `label` and `platform`.
- Display a friendly `"No links found"` state if the search yields zero matching links.

### 🎯 Acceptance Criteria Met
- [x] The search bar filters links instantly as the user types.
- [x] The search is case-insensitive.
- [x] If no links match the query, a friendly "No links found" message is displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link search to profile cards.
  * Search supports labels and platforms while preserving grouped matches.
  * Added a “No links found” state when searches return no results.
  * Search results now display social links, newsletters, and regular links appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->