### PR TITLE
fix: public resume PDF 500s on names with empty/consecutive/trailing spaces

### DIFF
--- a/lib/generateResumePDF.tsx
+++ b/lib/generateResumePDF.tsx
@@ -111,7 +111,8 @@ const styles = StyleSheet.create({
 
 function getInitials(name: string): string {
   return name
-    .split(" ")
+    .split(/\s+/)
+    .filter(Boolean)
     .map((part) => part[0].toUpperCase())
     .join("")
     .toLocaleUpperCase()


### PR DESCRIPTION
Closes #674

### Problem
`getInitials` did `name.split(" ").map((part) => part[0].toUpperCase())`. A name with a double/leading/trailing space (e.g. `"John  Doe"`) yields an empty token, so `""[0]` is `undefined` → `undefined.toUpperCase()` throws. Names aren’t trimmed/collapsed on write, so `GET /api/export/resume/<username>` returns **500** for any such user (triggerable by any visitor).

### Fix
Split on `/\s+/` and `filter(Boolean)` to drop empty tokens before indexing.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume PDF initials generation for names with multiple or irregular spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->