### PR TITLE
fix: /api/admin/verify-user returns the full target User row (credential leak)

### DIFF
--- a/app/api/admin/verify-user/route.ts
+++ b/app/api/admin/verify-user/route.ts
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
         const updatedUser = await prisma.user.update({
             where: { id: targetUserId },
             data: { isVerified },
+            select: { id: true, username: true, isVerified: true },
         });
 
         return NextResponse.json({ success: true, user: updatedUser });


### PR DESCRIPTION
Closes #673

### Problem
```ts
const updatedUser = await prisma.user.update({ where: { id: targetUserId }, data: { isVerified } });
return NextResponse.json({ success: true, user: updatedUser });
```
`prisma.user.update` returns every scalar column, so the response leaked the target user’s `password` (bcrypt hash), `totpSecret`, `recoveryCodes`, and `email` to the admin’s browser/network/logs — the "sensitive fields without a `select`" class, and it exposes *other* users’ credential material.

### Fix
Add `select: { id: true, username: true, isVerified: true }` to the update.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._