### PR TITLE
fix: PIN-protected link URLs leaked via public /api/extension/user/[username]

### DIFF
--- a/app/api/extension/user/[username]/route.ts
+++ b/app/api/extension/user/[username]/route.ts
@@ -25,6 +25,7 @@ export async function GET(
                         platform: true,
                         url: true,
                         label: true,
+                        pinCode: true,
                     },
                     orderBy: {
                         position: 'asc'
@@ -46,7 +47,13 @@ export async function GET(
                 username: user.username,
                 image: user.image,
             },
-            links: user.links
+            // PIN-locked links must not expose their destination here (same as
+            // the public profile, which hides it behind PIN verification).
+            links: user.links.map(({ pinCode, url, ...link }) => ({
+                ...link,
+                url: pinCode ? null : url,
+                locked: Boolean(pinCode),
+            }))
         }, {
             // Allow CORS for the chrome extension
             headers: {


### PR DESCRIPTION
Closes #672

### Problem
The extension endpoint selected `url` for every `isPublic` link with no `pinCode` handling, so an unauthenticated `GET /api/extension/user/<username>` returned the real destination of **pin-locked** links — bypassing the PIN gate that the profile/redirect paths enforce (the profile shows `<LockedLinkView>` and only reveals the URL after `verifyPinAction`).

### Fix
Select `pinCode` and, in the response, blank the `url` (and mark `locked: true`) for any link that has a `pinCode`, without exposing `pinCode` itself. Non-locked links are unchanged.

### Testing
- `npx tsc --noEmit` clean on the route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._