### PR TITLE
fix: /api/username/create returns the full User row (leaks hash + TOTP secret)

### DIFF
--- a/app/api/username/create/route.ts
+++ b/app/api/username/create/route.ts
@@ -36,6 +36,7 @@ export async function POST(req: NextRequest) {
     const user = await prisma.user.update({
       where: { id: userId },
       data: { username },
+      select: { id: true, username: true },
     });
 
     return NextResponse.json({ success: true, user }, { status: 200 });


### PR DESCRIPTION
Closes #555

### Problem
```ts
const user = await prisma.user.update({ where: { id: userId }, data: { username } });
return NextResponse.json({ success: true, user }, { status: 200 });
```
`prisma.user.update` returns every scalar column, so the response body leaked the caller’s `password` (bcrypt hash), `totpSecret`, `recoveryCodes`, and `email` to the browser.

### Fix
Add `select: { id: true, username: true }` to the update so only non-sensitive fields are returned.

### Testing
- `npx tsc --noEmit` clean on the route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username update responses by returning only the relevant user ID and username information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->