### PR TITLE
fix: login is case-sensitive on email but registration lowercases it

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -66,8 +66,12 @@ export const authOptions: NextAuthOptions = {
             async authorize(credentials) {
                 if (!credentials?.email || !credentials.password) return null;
 
+                // Registration stores email lowercased/trimmed, so look it up
+                // the same way — otherwise a differently-cased login is rejected.
+                const email = credentials.email.trim().toLowerCase();
+
                 const user = await prisma.user.findUnique({
-                    where: { email: credentials.email },
+                    where: { email },
                 });
 
                 if (!user || !user.password) return null;


### PR DESCRIPTION
Closes #557

### Problem
Registration normalizes the email (`body.email.trim().toLowerCase()`), but the credentials `authorize` looked the user up with the raw typed email:
```ts
const user = await prisma.user.findUnique({ where: { email: credentials.email } });
```
So a user who registered `John@X.com` (stored `john@x.com`) and later typed `John@X.com` at login matched no record and was rejected.

### Fix
Normalize the email the same way before the lookup: `credentials.email.trim().toLowerCase()`.

### Testing
- `npx tsc --noEmit` clean on `lib/auth.ts`.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._