### PR TITLE
fix: register rate limit bypassable via spoofed X-Forwarded-For

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -3,14 +3,17 @@ import bcrypt from "bcryptjs";
 import crypto from "crypto";
 import prisma from "@/lib/prisma";
 import { checkRateLimit } from "@/lib/rateLimit";
+import { getForwardedIp } from "@/lib/analyticsUtils";
 import { sendVerificationEmail } from "@/lib/email";
 
 const REGISTER_LIMIT = 5;
 const REGISTER_WINDOW_MS = 60 * 60 * 1000;
 
 export async function POST(req: Request) {
-    const ip =
-        req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    // Use the spoof-resistant client IP (trusts x-real-ip set by the platform)
+    // rather than the raw first x-forwarded-for value, which a client can
+    // rotate to bypass the per-IP registration rate limit.
+    const ip = getForwardedIp(req.headers) ?? "unknown";
 
     if (!(await checkRateLimit(`register:${ip}`, REGISTER_LIMIT, REGISTER_WINDOW_MS))) {
         return NextResponse.json(


### PR DESCRIPTION
Closes #559

### Problem
```ts
const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
if (!(await checkRateLimit(`register:${ip}`, ...))) { ... }
```
The first `x-forwarded-for` entry is client-controlled, so an attacker can rotate the header to get a fresh rate-limit bucket on every request and bypass the per-IP registration limit entirely.

### Fix
Use the existing `getForwardedIp(req.headers)` helper (already used for analytics), which trusts `x-real-ip` (set by Vercel/nginx, not client-spoofable) and only honours `x-forwarded-for` when the direct upstream is a private proxy.

### Testing
- `npx tsc --noEmit` clean on the route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._