### PR TITLE
fix: /api/subscribe has no rate limit (subscriber bombing & enumeration)

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,8 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { checkRateLimit } from "@/lib/rateLimit";
+import { getForwardedIp } from "@/lib/analyticsUtils";
+
+const SUBSCRIBE_LIMIT = 10;
+const SUBSCRIBE_WINDOW_MS = 60 * 60 * 1000;
 
 export async function POST(req: NextRequest) {
   try {
+    // This endpoint is intentionally public (profile subscribe form), so
+    // rate-limit per client IP to prevent subscriber bombing and username
+    // enumeration via unlimited requests.
+    const ip = getForwardedIp(req.headers) ?? "unknown";
+    if (!(await checkRateLimit(`subscribe:${ip}`, SUBSCRIBE_LIMIT, SUBSCRIBE_WINDOW_MS))) {
+      return NextResponse.json(
+        { error: "Too many requests. Please slow down." },
+        { status: 429, headers: { "Retry-After": String(SUBSCRIBE_WINDOW_MS / 1000) } }
+      );
+    }
+
     const body = await req.json();
     const email = typeof body.email === "string" ? body.email.trim() : "";
     const username = body.username;


### PR DESCRIPTION
Closes #558

### Problem
`POST /api/subscribe` (public) had no rate limiting, so it could be abused to:
- **Subscriber-bomb** a profile with unlimited subscriber rows, and
- **Enumerate usernames** — the distinct `404` (no user) / `403` (capture disabled) / `200` responses reveal which usernames exist and have email capture enabled — via unlimited requests.

### Fix
Add a per-IP rate limit (10/hour) at the top of the handler using the existing `checkRateLimit` + the spoof-resistant `getForwardedIp` helper. The endpoint stays public (it’s the profile subscribe form) but abuse is bounded.

### Testing
- `npx tsc --noEmit` clean on the route.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._