### PR TITLE
feat: link oauth accounts on sign in (#684)

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -41,7 +41,6 @@ export const authOptions: NextAuthOptions = {
                   Google({
                       clientId: process.env.GOOGLE_CLIENT_ID,
                       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-                      allowDangerousEmailAccountLinking: true,
                   }),
               ]
             : []),
@@ -51,7 +50,6 @@ export const authOptions: NextAuthOptions = {
                   GitHub({
                       clientId: process.env.GITHUB_CLIENT_ID,
                       clientSecret: process.env.GITHUB_CLIENT_SECRET,
-                      allowDangerousEmailAccountLinking: true,
                   }),
               ]
             : []),
@@ -104,6 +102,58 @@ events: {
     },
 },
     callbacks: {
+        async signIn({ user, account, profile }) {
+            if (account && oauthProviders.has(account.provider)) {
+                if (!user.email) return true;
+
+                let isVerified = false;
+                if (account.provider === "google") {
+                    isVerified = (profile as any)?.email_verified === true;
+                } else if (account.provider === "github") {
+                    // NextAuth's GitHub provider only populates user.email with verified emails
+                    isVerified = true;
+                }
+
+                if (!isVerified) return true;
+
+                const existingUser = await prisma.user.findUnique({
+                    where: { email: user.email },
+                    include: { accounts: true },
+                });
+
+                if (existingUser) {
+                    const isAlreadyLinked = existingUser.accounts.some(
+                        (acc) => acc.provider === account.provider
+                    );
+
+                    if (!isAlreadyLinked) {
+                        await prisma.account.create({
+                            data: {
+                                userId: existingUser.id,
+                                type: account.type,
+                                provider: account.provider,
+                                providerAccountId: account.providerAccountId,
+                                access_token: account.access_token,
+                                token_type: account.token_type,
+                                scope: account.scope,
+                                id_token: account.id_token,
+                                expires_at: account.expires_at,
+                                refresh_token: account.refresh_token,
+                                session_state: account.session_state as string | undefined,
+                            },
+                        });
+
+                        if (!existingUser.emailVerified) {
+                            await prisma.user.update({
+                                where: { id: existingUser.id },
+                                data: { emailVerified: new Date() },
+                            });
+                        }
+                    }
+                }
+            }
+            return true;
+        },
         async jwt({ token, trigger, session, user, account, profile }) {
             // Immediately invalidate token if user account was deleted
             if (token.sub && (await isUserSessionInvalidated(token.sub))) {


### PR DESCRIPTION
# Description
This PR resolves the `OAuthAccountNotLinked` error by implementing advanced NextAuth callbacks to automatically link incoming OAuth accounts to an existing user account if the email addresses match.

Fixes #684

## Changes Made
- Added a custom `signIn` callback in `lib/auth.ts` to intercept OAuth sign-ins (Google, GitHub).
- The callback checks the database for an existing user matching the incoming OAuth email.
- If a match is found and the provider isn't already linked, it automatically creates a new `Account` record in Prisma linking the OAuth provider to the existing user.
- The email is also automatically marked as verified if it wasn't already.

## Why this is needed
Previously, if a user originally signed up with an Email/Password and later tried to log in using an OAuth provider with the same email (e.g., "Sign in with GitHub"), NextAuth would throw an `OAuthAccountNotLinked` error and block access. This PR creates a seamless login experience by securely merging the accounts in the background.

## Testing Instructions
1. Register a new account using Email and Password.
2. Log out of the application.
3. Click "Sign in with GitHub" (or Google) using the same email address.
4. You should be seamlessly logged into the dashboard without encountering any account linking errors.
5. Verify in the database that both the Credentials and the OAuth provider are successfully linked to the same `User` record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in by linking recognized provider accounts to existing users.
  * Existing users’ email verification status is updated when their OAuth account is linked.
  * Sign-in continues to work for non-OAuth providers and OAuth accounts without email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->