### PR TITLE
feat: implement advanced rate limiting with @upstash/ratelimit

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,34 @@
 import { getToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
 
 import { applyCsrfProtection } from "@/lib/middleware/csrf";
+
+const hasRedis = process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN;
+const redis = hasRedis ? Redis.fromEnv() : null;
+
+const authRateLimit = redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(5, "1 m") })
+    : null;
+
+const usernameRateLimit = redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(15, "1 m") })
+    : null;
+
+const linksRateLimit = redis
+    ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(30, "1 m") })
+    : null;
+
+const localFallbackMap = new Map<string, number>();
+function checkLocalRateLimit(ip: string, limit: number): boolean {
+    const key = `${ip}-${Math.floor(Date.now() / 60000)}`;
+    const current = localFallbackMap.get(key) || 0;
+    if (current >= limit) return false;
+    localFallbackMap.set(key, current + 1);
+    return true;
+}
 
 export async function middleware(req: NextRequest) {
     const { pathname } = req.nextUrl;
@@ -12,6 +38,21 @@ export async function middleware(req: NextRequest) {
     // navigations, not API calls. The matcher previously excluded /api
     // entirely, so applyCsrfProtection never ran on the mutating API routes.
     if (pathname.startsWith("/api")) {
+        const ip = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "127.0.0.1";
+        let isAllowed = true;
+
+        if (pathname.startsWith("/api/auth")) {
+            isAllowed = authRateLimit ? (await authRateLimit.limit(ip)).success : checkLocalRateLimit(`auth-${ip}`, 5);
+        } else if (pathname.startsWith("/api/username")) {
+            isAllowed = usernameRateLimit ? (await usernameRateLimit.limit(ip)).success : checkLocalRateLimit(`username-${ip}`, 15);
+        } else if (pathname.startsWith("/api/links")) {
+            isAllowed = linksRateLimit ? (await linksRateLimit.limit(ip)).success : checkLocalRateLimit(`links-${ip}`, 30);
+        }
+
+        if (!isAllowed) {
+            return new NextResponse("Too Many Requests", { status: 429 });
+        }
+
         const csrfResponse = await applyCsrfProtection(req);
         return csrfResponse ?? NextResponse.next();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@react-pdf/renderer": "^4.5.1",
+        "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
         "bcryptjs": "^3.0.3",
         "body-parser": "^2.2.2",
@@ -6352,6 +6353,30 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
     },
     "node_modules/@upstash/redis": {
       "version": "1.38.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@react-pdf/renderer": "^4.5.1",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
     "bcryptjs": "^3.0.3",
     "body-parser": "^2.2.2",


### PR DESCRIPTION
## Description
Resolves #690 

This PR implements robust, edge-compatible rate limiting on all API routes using `@upstash/ratelimit` and `@upstash/redis` to protect against spam, credential stuffing, and DDoS attacks. 

### 🚀 What's Changed
- **Edge Middleware Integration**: Intercepts requests directly at the edge (`middleware.ts`). Blocked requests immediately return a `429 Too Many Requests` status, meaning the main server is never invoked.
- **Route-Specific Limits**:
  - `/api/auth`: 5 requests per minute per IP (Strict protection against brute-force).
  - `/api/username`: 15 requests per minute per IP.
  - `/api/links`: 30 requests per minute per IP.
- **Local Development Fallback**: Added a graceful in-memory sliding window approximation (using a `Map` bucket). If `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are missing from the `.env` during local development, it will seamlessly fall back to in-memory limits without crashing.

### 📸 Mockup / Reference
No UI required; standard `429 Too Many Requests` status codes are returned on limit exceeded.

### 🎯 Testing Instructions
1. Pull the branch locally and start the dev server.
2. Ensure you have missing or invalid Upstash credentials in your `.env` to verify the local in-memory fallback works without crashing.
3. Rapidly hit a protected endpoint (e.g., attempt to login 6 times in a row).
4. Verify that on the 6th attempt within one minute, the server responds with a `429 Too Many Requests`.