### PR TITLE
fix: disable Add Link button when URL or platform is empty

### DIFF
--- a/app/dashboard/AddLinkBox.tsx
+++ b/app/dashboard/AddLinkBox.tsx
@@ -39,6 +39,7 @@ export default function AddLinkBox({
     const [platform, setPlatform] = useState("");
     const [loading, setLoading] = useState(false);
     const [showAdvanced, setShowAdvanced] = useState(false);
+    const [urlError, setUrlError] = useState("");
 
     function handleCancel() {
         setUrl("");
@@ -137,8 +138,23 @@ export default function AddLinkBox({
             <Input
                 placeholder="Paste your link here..."
                 value={url}
-                onChange={(e) => setUrl(e.target.value)}
+                onChange={(e) => {
+                    setUrl(e.target.value);
+                    if (e.target.value.trim()) {
+                        const validation = validateUrl(e.target.value);
+                        setUrlError(validation.valid ? "" : validation.error);
+                    } else {
+                        setUrlError("");
+                    }
+                }}
+                aria-invalid={!!urlError}
+                aria-describedby={urlError ? "url-error" : undefined}
             />
+            {urlError && (
+                <p id="url-error" className="text-xs text-red-500 mt-1" role="alert">
+                    {urlError}
+                </p>
+            )}
 
             <div>
                 <button
@@ -166,8 +182,17 @@ export default function AddLinkBox({
                 <Button onClick={handleCancel} variant="outline" disabled={loading} className="flex-1">
                     Cancel
                 </Button>
-                <Button onClick={submit} disabled={loading} className="flex-1">
-                    {loading ? "Adding…" : "Add link"}
+                <Button
+                    onClick={submit}
+                    disabled={loading || !url.trim() || !platform}
+                    className="flex-1"
+                    aria-busy={loading}
+                >
+                    {loading ? (
+                        <span className="flex items-center gap-2">
+                            <span className="animate-spin">⟳</span> Adding…
+                        </span>
+                    ) : "Add link"}
                 </Button>
             </div>
         </div>

--- a/app/dashboard/AddLinkBox.tsx
+++ b/app/dashboard/AddLinkBox.tsx
@@ -46,6 +46,7 @@ export default function AddLinkBox({
         setLabel("");
         setAlias("");
         setPlatform("");
+        setUrlError("");
         onCancel?.();
     }
 


### PR DESCRIPTION
## Description
Disable the Add Link button when URL or platform field is empty.

## Problem
Users could submit empty links, resulting in broken redirect routes and unnecessary database entries.

## Solution
Added `disabled={loading || !url.trim() || !platform}` to the submit button, preventing form submission when required fields are empty.

## Related Issue
Relates to #267

## Type of Change
- [x] Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented submitting an empty or whitespace-only URL when adding a link.
  * The Add Link button remains disabled until a valid URL and platform are selected.
  * Added inline URL validation feedback with improved accessibility.
  * Added a loading indicator while a link is being submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->