### PR TITLE
feat(profile): add profile completeness score

### DIFF
--- a/lib/profileCompleteness.test.ts
+++ b/lib/profileCompleteness.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computeProfileCompleteness,
+  type CompletenessInput,
+} from "@/lib/profileCompleteness";
+
+const base: CompletenessInput = {
+  image: null,
+  bio: null,
+  seoTitle: null,
+  seoDescription: null,
+  resumeUrl: null,
+  isVerified: false,
+  publicLinkCount: 0,
+};
+
+test("empty profile scores zero", () => {
+  const result = computeProfileCompleteness(base);
+  assert.equal(result.score, 0);
+  assert.equal(result.completedCount, 0);
+  assert.equal(result.items.length, 8);
+  assert.equal(result.totalCount, 8);
+});
+
+test("fully complete profile scores 100", () => {
+  const result = computeProfileCompleteness({
+    image: "https://example.com/a.png",
+    bio: "Hello there",
+    seoTitle: "My page",
+    seoDescription: "About my page",
+    resumeUrl: "https://example.com/cv.pdf",
+    isVerified: true,
+    publicLinkCount: 5,
+  });
+  assert.equal(result.score, 100);
+  assert.equal(result.completedCount, 8);
+});
+
+test("whitespace-only text fields are not counted as done", () => {
+  const result = computeProfileCompleteness({
+    ...base,
+    bio: "   ",
+    seoTitle: "  ",
+  });
+  const bio = result.items.find((i) => i.key === "bio");
+  const seo = result.items.find((i) => i.key === "seoTitle");
+  assert.equal(bio?.done, false);
+  assert.equal(seo?.done, false);
+});
+
+test("public link thresholds are boundary-correct", () => {
+  const one = computeProfileCompleteness({ ...base, publicLinkCount: 1 });
+  assert.equal(one.items.find((i) => i.key === "firstLink")?.done, true);
+  assert.equal(one.items.find((i) => i.key === "threeLinks")?.done, false);
+
+  const three = computeProfileCompleteness({ ...base, publicLinkCount: 3 });
+  assert.equal(three.items.find((i) => i.key === "threeLinks")?.done, true);
+});
+
+test("partial profile scores the sum of completed weights", () => {
+  const result = computeProfileCompleteness({
+    ...base,
+    image: "https://example.com/a.png",
+    bio: "Hello",
+    publicLinkCount: 1,
+  });
+  // avatar (15) + bio (15) + firstLink (20) = 50
+  assert.equal(result.score, 50);
+  assert.equal(result.items.find((i) => i.key === "avatar")?.done, true);
+  assert.equal(result.items.find((i) => i.key === "verified")?.done, false);
+});
+
+test("score is always an integer in [0, 100]", () => {
+  for (const count of [0, 1, 2, 3, 4]) {
+    const { score } = computeProfileCompleteness({
+      ...base,
+      publicLinkCount: count,
+    });
+    assert.ok(Number.isInteger(score));
+    assert.ok(score >= 0 && score <= 100);
+  }
+});

--- a/lib/profileCompleteness.ts
+++ b/lib/profileCompleteness.ts
@@ -1,0 +1,74 @@
+export type CompletenessInput = {
+  image: string | null;
+  bio: string | null;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  resumeUrl: string | null;
+  isVerified: boolean;
+  publicLinkCount: number;
+};
+
+export type ChecklistItem = {
+  key: string;
+  label: string;
+  done: boolean;
+  weight: number;
+};
+
+export type ProfileCompleteness = {
+  score: number;
+  completedCount: number;
+  totalCount: number;
+  items: ChecklistItem[];
+};
+
+const isFilled = (value: string | null): boolean =>
+  typeof value === "string" && value.trim().length > 0;
+
+/**
+ * Score a public profile 0-100 against a weighted checklist and return the
+ * per-item breakdown. Pure and deterministic — the dashboard renders `score`
+ * as a progress bar and lists the undone `items` as next steps.
+ */
+export function computeProfileCompleteness(
+  input: CompletenessInput
+): ProfileCompleteness {
+  const items: ChecklistItem[] = [
+    { key: "avatar", label: "Add a profile photo", done: isFilled(input.image), weight: 15 },
+    { key: "bio", label: "Write a bio", done: isFilled(input.bio), weight: 15 },
+    {
+      key: "firstLink",
+      label: "Add your first public link",
+      done: input.publicLinkCount >= 1,
+      weight: 20,
+    },
+    {
+      key: "threeLinks",
+      label: "Add at least three public links",
+      done: input.publicLinkCount >= 3,
+      weight: 15,
+    },
+    { key: "seoTitle", label: "Set an SEO title", done: isFilled(input.seoTitle), weight: 10 },
+    {
+      key: "seoDescription",
+      label: "Set an SEO description",
+      done: isFilled(input.seoDescription),
+      weight: 10,
+    },
+    { key: "resume", label: "Link a resume", done: isFilled(input.resumeUrl), weight: 5 },
+    { key: "verified", label: "Verify your account", done: input.isVerified === true, weight: 10 },
+  ];
+
+  const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+  const doneWeight = items.reduce(
+    (sum, item) => (item.done ? sum + item.weight : sum),
+    0
+  );
+
+  return {
+    score: totalWeight === 0 ? 0 : Math.round((doneWeight / totalWeight) * 100),
+    completedCount: items.filter((item) => item.done).length,
+    totalCount: items.length,
+    items,
+  };
+}


### PR DESCRIPTION
## What & why

Closes #729.

Gives users a single 0–100 profile-completeness score plus a checklist of what's done/undone, so they know exactly what to fill in next.

## Changes

- **`lib/profileCompleteness.ts`** — pure `computeProfileCompleteness(input)` scoring a weighted checklist (avatar 15, bio 15, first link 20, three links 15, SEO title 10, SEO description 10, resume 5, verified 10) → `{ score, completedCount, totalCount, items }`. Whitespace-only text fields don't count. No `prisma`/`server-only` imports, so it stays a pure, testable function.

## Testing

- **`lib/profileCompleteness.test.ts`** — pure `node:test` (no module mocks, so it passes on Node 20 and 22): empty→0, complete→100, whitespace-not-done, link boundaries (≥1/≥3), partial-sum, integer-in-range. `npx tsx --test lib/profileCompleteness.test.ts` → **6/6 pass (# fail 0)**.
- `eslint` clean on both files.

> Uses the repo's real test gate (`node:test`); avoids `mock.module` so it's robust across Node versions.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile completeness scoring from 0–100.
  * Evaluates key profile details, including avatar, bio, links, SEO information, resume, and verification.
  * Provides completed-item counts and a breakdown of profile checklist progress.

* **Tests**
  * Added coverage for empty, complete, partial, and boundary-value profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->